### PR TITLE
add TIR for mono repo enhancements

### DIFF
--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -171,6 +171,7 @@
         </table>
 
         <h3 id="subcomponents"><span>2.2</span>Components</h3>
+		Note: {{deployNote}}
         <p>The following components have been successfully installed:</p>
 
         {{#data.repo}}
@@ -182,7 +183,7 @@
 		      <table>
 		      {{#each .}}
 		        <tr>
-		          BuildConfig: {{@key}}
+		          <h5>BuildConfig: {{@key}}</h5>
 		          <table>
 		            <tr>
 		                <th>Name</th>
@@ -204,7 +205,7 @@
 		      <table>
 		      {{#each .}}
 		        <tr>
-		          DeploymentConfig: {{@key}}
+		          <h5>DeploymentConfig: {{@key}}</h5>
 		          <table>
 		            <tr>
 		                <th>Name</th>

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -171,7 +171,7 @@
         </table>
 
         <h3 id="subcomponents"><span>2.2</span>Components</h3>
-        <p><b>{{{data.deployNote}}}</b></p>
+        <p><b>{{{deployNote}}}</b></p>
         
         {{#data.repo}}
         <p>The following components have been successfully installed:<b>{{id}}</b></p>

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -213,14 +213,6 @@
 		            {{#each .}}
 		              <tr>
 		                <td>{{@key}}:</td><td class="content-wrappable">{{this}}</td>
-		                {{#each .}}
-		                <table>
-		                  <tr>
-		                    <td>{{@../key}}-{{@key}}:</td><td class="content-wrappable">{{this}}</td>
-		                  <tr>
-		                </table>
-		                {{/each}}
-		
 		              <tr>
 		            {{/each}}
 		          </table>

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -171,7 +171,7 @@
         </table>
 
         <h3 id="subcomponents"><span>2.2</span>Components</h3>
-		Note: {{data.deployNote}}
+		<!-- Note: {{data.deployNote}} -->
         <p>The following components have been successfully installed:</p>
 
         {{#data.repo}}
@@ -183,7 +183,7 @@
 		      <table>
 		      {{#each .}}
 		        <tr>
-		          <h5>BuildConfig: {{@key}}</h5>
+		          <b>BuildConfig: {{@key}}</b>
 		          <table>
 		            <tr>
 		                <th>Name</th>
@@ -205,7 +205,7 @@
 		      <table>
 		      {{#each .}}
 		        <tr>
-		          <h5>DeploymentConfig: {{@key}}</h5>
+		          <b>DeploymentConfig: {{@key}}<b>
 		          <table>
 		            <tr>
 		                <th>Name</th>

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -230,6 +230,7 @@
 		    </tr>
 		  {{/deployments}}
 		</table>
+        {{/openShiftData}}
         {{/data.repo}}
     </div>
 

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -190,7 +190,7 @@
 		            </tr>
 		            {{#each .}}
 		              <tr>
-		                <td>{{@key}}</td><td>{{.}}</td>
+		                <td>{{@key}}</td><td class="content-wrappable">{{.}}</td>
 		              <tr>
 		            {{/each}}
 		          </table>

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -171,7 +171,7 @@
         </table>
 
         <h3 id="subcomponents"><span>2.2</span>Components</h3>
-        <p><b>{{{deployNote}}}</b></p>
+        <p><b>Generated Note: {{deployNote}}</b></p>
         
         {{#data.repo}}
         <p>The following components have been successfully installed:<b>{{id}}</b></p>

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -175,44 +175,61 @@
 
         {{#data.repo}}
         <h4>{{id}}</h4>
-        <table>
-            <tr>
-                <th>Name</th>
-                <th class="content-wrappable">Value</th>
-            </tr>
-            <tr>
-                <td>OCP Build Id</td>
-                <td class="content-wrappable">{{openShiftData.ocpBuildId}}</td>
-            </tr>
-            <tr>
-                <td>Created docker image</td>
-                <td class="content-wrappable">{{openShiftData.ocpDockerImage}}</td>
-            </tr>
-            <tr>
-                <td>OCP Deployment Id</td>
-                <td class="content-wrappable">{{openShiftData.ocpDeploymentId}}</td>
-            </tr>
-            <tr>
-                <td>Pod Name</td>
-                <td class="content-wrappable">{{openShiftData.podName}}</td>
-            </tr>
-            <tr>
-                <td>Namespace</td>
-                <td class="content-wrappable">{{openShiftData.podNamespace}}</td>
-            </tr>
-            <tr>
-                <td>Pod Creation Timestamp</td>
-                <td class="content-wrappable">{{openShiftData.podCreationTimestamp}}</td>
-            </tr>
-            <tr>
-                <td>Pod Node</td>
-                <td class="content-wrappable">{{openShiftData.podNode}}</td>
-            </tr>
-            <tr>
-                <td>Pod Status</td>
-                <td class="content-wrappable">{{openShiftData.podStatus}}</td>
-            </tr>
-        </table>
+        {{#openShiftData}}
+		<table>
+		  {{#builds}}
+		    <tr>
+		      <table>
+		      {{#each .}}
+		        <tr>
+		          BuildConfig: {{@key}}
+		          <table>
+		            <tr>
+		                <th>Name</th>
+		                <th class="content-wrappable">Value</th>
+		            </tr>
+		            {{#each .}}
+		              <tr>
+		                <td>{{@key}}:</td><td>{{.}}</td>
+		              <tr>
+		            {{/each}}
+		          </table>
+		        </tr>
+		      {{/each}}
+		      </table
+		    </tr>
+		  {{/builds}}
+		  {{#deployments}}
+		    <tr>
+		      <table>
+		      {{#each .}}
+		        <tr>
+		          DeploymentConfig: {{@key}}
+		          <table>
+		            <tr>
+		                <th>Name</th>
+		                <th class="content-wrappable">Value</th>
+		            </tr>		          
+		            {{#each .}}
+		              <tr>
+		                <td>{{@key}}:</td><td class="content-wrappable">{{this}}</td>
+		                {{#each .}}
+		                <table>
+		                  <tr>
+		                    <td>{{@../key}}-{{@key}}:</td><td class="content-wrappable">{{this}}</td>
+		                  <tr>
+		                </table>
+		                {{/each}}
+		
+		              <tr>
+		            {{/each}}
+		          </table>
+		        </tr>
+		      {{/each}}
+		      </table
+		    </tr>
+		  {{/deployments}}
+		</table>
         {{/data.repo}}
     </div>
 

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -171,7 +171,7 @@
         </table>
 
         <h3 id="subcomponents"><span>2.2</span>Components</h3>
-		Note: {{deployNote}}
+		Note: {{data.deployNote}}
         <p>The following components have been successfully installed:</p>
 
         {{#data.repo}}

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -171,7 +171,6 @@
         </table>
 
         <h3 id="subcomponents"><span>2.2</span>Components</h3>
-		<!-- Note: {{data.deployNote}} -->
         <p>The following components have been successfully installed:</p>
 
         {{#data.repo}}

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -171,7 +171,7 @@
         </table>
 
         <h3 id="subcomponents"><span>2.2</span>Components</h3>
-        <p><b>{{{data.deploynoteData}}}</b>
+        <p><b>{{{data.deployNote}}}</b></p>
         <p>The following components have been successfully installed:</p>
 
         {{#data.repo}}

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -183,7 +183,7 @@
 		      <table>
 		      {{#each .}}
 		        <tr>
-		          <b>BuildConfig: {{@key}}</b>
+		          BuildConfig: {{@key}}
 		          <table>
 		            <tr>
 		                <th>Name</th>
@@ -205,7 +205,7 @@
 		      <table>
 		      {{#each .}}
 		        <tr>
-		          <b>DeploymentConfig: {{@key}}<b>
+		          DeploymentConfig: {{@key}}
 		          <table>
 		            <tr>
 		                <th>Name</th>

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -171,6 +171,7 @@
         </table>
 
         <h3 id="subcomponents"><span>2.2</span>Components</h3>
+        <p><b>{{{data.deploynoteData}}}</b>
         <p>The following components have been successfully installed:</p>
 
         {{#data.repo}}
@@ -182,7 +183,7 @@
 		      <table>
 		      {{#each .}}
 		        <tr>
-		          BuildConfig: {{@key}}
+		          BuildConfig: <b>{{@key}}</b>
 		          <table>
 		            <tr>
 		                <th>Name</th>
@@ -204,7 +205,7 @@
 		      <table>
 		      {{#each .}}
 		        <tr>
-		          DeploymentConfig: {{@key}}
+		          DeploymentConfig: <b>{{@key}}</b>
 		          <table>
 		            <tr>
 		                <th>Name</th>

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -172,10 +172,10 @@
 
         <h3 id="subcomponents"><span>2.2</span>Components</h3>
         <p><b>{{{data.deployNote}}}</b></p>
-        <p>The following components have been successfully installed:</p>
-
+        
         {{#data.repo}}
-        <h4>{{id}}</h4>
+        <p>The following components have been successfully installed:<b>{{id}}</b></p>
+
         {{#openShiftData}}
 		<table>
 		  {{#builds}}
@@ -191,7 +191,7 @@
 		            </tr>
 		            {{#each .}}
 		              <tr>
-		                <td>{{@key}}:</td><td>{{.}}</td>
+		                <td>{{@key}}</td><td>{{.}}</td>
 		              <tr>
 		            {{/each}}
 		          </table>
@@ -213,7 +213,7 @@
 		            </tr>		          
 		            {{#each .}}
 		              <tr>
-		                <td>{{@key}}:</td><td class="content-wrappable">{{this}}</td>
+		                <td>{{@key}}</td><td class="content-wrappable">{{this}}</td>
 		              <tr>
 		            {{/each}}
 		          </table>

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -171,11 +171,10 @@
         </table>
 
         <h3 id="subcomponents"><span>2.2</span>Components</h3>
-        <p><b>Generated Note: {{deployNote}}</b></p>
+        <p><b>Note:</b> {{deployNote}}</p>
         
         {{#data.repo}}
         <p>The following components have been successfully installed:<b>{{id}}</b></p>
-
         {{#openShiftData}}
 		<table>
 		  {{#builds}}


### PR DESCRIPTION
follow up from ods-mro-jenkins-shared-library#188 - a deploynote was now added as well, to denote wether a build and / or deploy did happen

![image](https://user-images.githubusercontent.com/40628552/79423386-d0187900-7fbe-11ea-8002-294cb48658c3.png)
