### PR TITLE
TIR references wrong documentation chapter in Jira for Abbreviations

### DIFF
--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -276,7 +276,7 @@
         <p>{{{data.sections.sec5s1.content}}}</p>
 
         <h3 id="section_5_2"><span>5.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec5s1.content}}}</p>
+        <p>{{{data.sections.sec5s2.content}}}</p>
     </div>
 
     <div class="page">


### PR DESCRIPTION
Closes #20 