### PR TITLE
Bugfix/big table content overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
 # Changelog
 
 ## Unreleased
+
+### Fixed - 2021-04-15
+- Bugfix/big table content overflow ([#32](https://github.com/opendevstack/ods-document-generation-templates/pull/32))
+
+## 1.1

--- a/templates/CFTP-1.html.tmpl
+++ b/templates/CFTP-1.html.tmpl
@@ -343,7 +343,7 @@
             <li>All executed acceptance test cases</li>
             <li>Discrepancy log</li>
         </ul>
-		<table>
+        <table>
             <tr>
                 <td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
             </tr>

--- a/templates/CFTP-1.html.tmpl
+++ b/templates/CFTP-1.html.tmpl
@@ -124,7 +124,11 @@
 
     <div class="page">
         <h2 id="section_2"><span>2</span>Scope</h2>
-        <p>{{{data.sections.sec2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -181,7 +185,11 @@
 
     <div class="page">
         <h2 id="section_5"><span>5</span>Operational Qualification Activities and Training</h2>
-        <p>{{{data.sections.sec5.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_5_1"><span>5.1</span>Test Procedure 1: Verification of Operational Documentation</h3>
         <p>As part of the Integration Testing the following documentation will be verified for all relevant subjects listed in the Qualification Plan.</p>
@@ -194,7 +202,11 @@
 
         <h3 id="section_5_2"><span>5.2</span>Test Procedure 2: Verification of Training Documentation</h3>
         <p>List the applicable procedures in which the Integration Testing participants must be trained before executing their portions of the Functional Testing Plan. Describe when and how the training will take place.</p>
-        <p>{{{data.sections.sec5s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s2.content}}}</td>
+            </tr>
+        </table>
         <p>Verify that an approved training plan exists, if justified, for all personnel involved in operating and maintaining the Infrastructure System.</p>
     </div>
 
@@ -205,7 +217,11 @@
         <p>The purpose of the integration testing is to verify the functional, non-functional and reliability between the modules that are integrated and work within the specifications as defined in the functional and/or configuration specifications.</p>
 
         <h3 id="section_6_2"><span>6.2</span>Scope of Integration Testing</h3>
-        <p>{{{data.sections.sec6s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -274,19 +290,31 @@
         </ul>
 
         <p>Test execution and test result review must be independent, i.e. for any individual test case the Tester and the Test Administrator must be different individuals.</p>
-        <p>{{{data.sections.sec8s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec8s2.content}}}</td>
+            </tr>
+        </table>
         <p>The training records of all testers should be verified prior to initiating testing.</p>
     </div>
 
 
     <div class="page">
         <h2 id="section_9"><span>9</span>Traceability Matrix</h2>
-        <p>{{{data.sections.sec9.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec9.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_10"><span>10</span>Validation Environment</h2>
-        <p>{{{data.sections.sec10.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec10.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -315,17 +343,29 @@
             <li>All executed acceptance test cases</li>
             <li>Discrepancy log</li>
         </ul>
-		<p>{{{data.sections.sec12.content}}}</p>
+		<table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_13"><span>13</span>Definitions and Abbreviations</h2>
 
         <h3 id="section_13_1"><span>13.1</span>Definitions</h3>
-        <p>{{{data.sections.sec13s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec13s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -384,7 +424,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec15.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+            </tr>
+        </table>
     </div>
 </body>
 </html>

--- a/templates/CFTP-3.html.tmpl
+++ b/templates/CFTP-3.html.tmpl
@@ -348,7 +348,7 @@
             <li>All executed acceptance test cases</li>
             <li>Discrepancy log</li>
         </ul>
-		<table>
+        <table>
             <tr>
                 <td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
             </tr>

--- a/templates/CFTP-3.html.tmpl
+++ b/templates/CFTP-3.html.tmpl
@@ -124,7 +124,11 @@
 
     <div class="page">
         <h2 id="section_2"><span>2</span>Scope</h2>
-        <p>{{{data.sections.sec2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -181,7 +185,11 @@
 
     <div class="page">
         <h2 id="section_5"><span>5</span>Operational Qualification Activities and Training</h2>
-        <p>{{{data.sections.sec5.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_5_1"><span>5.1</span>Test Procedure 1: Verification of Operational Documentation</h3>
         <p>As part of the Integration Testing the following documentation will be verified for all relevant subjects listed in the Qualification Plan.</p>
@@ -194,7 +202,11 @@
 
         <h3 id="section_5_2"><span>5.2</span>Test Procedure 2: Verification of Training Documentation</h3>
         <p>List the applicable procedures in which the Integration Testing participants must be trained before executing their portions of the Functional Testing Plan. Describe when and how the training will take place.</p>
-        <p>{{{data.sections.sec5s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s2.content}}}</td>
+            </tr>
+        </table>
         <p>Verify that an approved training plan exists, if justified, for all personnel involved in operating and maintaining the Infrastructure System.</p>
     </div>
 
@@ -216,7 +228,11 @@
         <p>The purpose of the functional testing is to verify that the system is operational and works within the specifications as defined in the functional specifications and / or configuration specifications.</p>
 
         <h4 id="section_7_1_2"><span>7.1.2 </span>Scope of Functional Testing</h4>
-        <p>{{{data.sections.sec7s1s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7s1s2.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_7_2"><span>7.2</span>Non-Functional Testing</h3>
 
@@ -224,7 +240,12 @@
         <p>The purpose of Non-Functional testing is to check non-functional aspects (performance, usability, reliability, etc) of a software application. It is designed to test the readiness of a system as per non-functional parameters which are never addressed by functional testing.</p>
 
         <h4 id="section_7_2_2"><span>7.2.2 </span>Scope of Non-Functional Testing</h4>
-        <p>{{{data.sections.sec7s2s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7s2s2.content}}}</td>
+            </tr>
+        </table>
+
     </div>
 
     <div class="page">
@@ -274,19 +295,31 @@
         </ul>
 
         <p>Test execution and test result review must be independent, i.e. for any individual test case the Tester and the Test Administrator must be different individuals.</p>
-        <p>{{{data.sections.sec8s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec8s2.content}}}</td>
+            </tr>
+        </table>
         <p>The training records of all testers should be verified prior to initiating testing.</p>
     </div>
 
 
     <div class="page">
         <h2 id="section_9"><span>9</span>Traceability Matrix</h2>
-        <p>{{{data.sections.sec9.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec9.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_10"><span>10</span>Validation Environment</h2>
-        <p>{{{data.sections.sec10.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec10.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -315,17 +348,29 @@
             <li>All executed acceptance test cases</li>
             <li>Discrepancy log</li>
         </ul>
-		<p>{{{data.sections.sec12.content}}}</p>
+		<table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_13"><span>13</span>Definitions and Abbreviations</h2>
 
         <h3 id="section_13_1"><span>13.1</span>Definitions</h3>
-        <p>{{{data.sections.sec13s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec13s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -384,7 +429,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec15.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+            </tr>
+        </table>
     </div>
 </body>
 </html>

--- a/templates/CFTP-4.html.tmpl
+++ b/templates/CFTP-4.html.tmpl
@@ -124,7 +124,11 @@
 
     <div class="page">
         <h2 id="section_2"><span>2</span>Scope</h2>
-        <p>{{{data.sections.sec2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -181,7 +185,11 @@
 
     <div class="page">
         <h2 id="section_5"><span>5</span>Operational Qualification Activities and Training</h2>
-        <p>{{{data.sections.sec5.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_5_1"><span>5.1</span>Test Procedure 1: Verification of Operational Documentation</h3>
         <p>As part of the Integration Testing the following documentation will be verified for all relevant subjects listed in the Qualification Plan.</p>
@@ -194,7 +202,11 @@
 
         <h3 id="section_5_2"><span>5.2</span>Test Procedure 2: Verification of Training Documentation</h3>
         <p>List the applicable procedures in which the Integration Testing participants must be trained before executing their portions of the Functional Testing Plan. Describe when and how the training will take place.</p>
-        <p>{{{data.sections.sec5s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s2.content}}}</td>
+            </tr>
+        </table>
         <p>Verify that an approved training plan exists, if justified, for all personnel involved in operating and maintaining the Infrastructure System.</p>
     </div>
 
@@ -205,7 +217,11 @@
         <p>The purpose of the integration testing is to verify the functional, non-functional and reliability between the modules that are integrated and work within the specifications as defined in the functional and/or configuration specifications.</p>
 
         <h3 id="section_6_2"><span>6.2</span>Scope of Integration Testing</h3>
-        <p>{{{data.sections.sec6s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -216,7 +232,11 @@
         <p>The purpose of the functional testing is to verify that the system is operational and works within the specifications as defined in the functional specifications and / or configuration specifications.</p>
 
         <h4 id="section_7_1_2"><span>7.1.2 </span>Scope of Functional Testing</h4>
-        <p>{{{data.sections.sec7s1s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7s1s2.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_7_2"><span>7.2</span>Non-Functional Testing</h3>
 
@@ -224,7 +244,11 @@
         <p>The purpose of Non-Functional testing is to check non-functional aspects (performance, usability, reliability, etc) of a software application. It is designed to test the readiness of a system as per non-functional parameters which are never addressed by functional testing.</p>
 
         <h4 id="section_7_2_2"><span>7.2.2 </span>Scope of Non-Functional Testing</h4>
-        <p>{{{data.sections.sec7s2s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7s2s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -274,19 +298,31 @@
         </ul>
 
         <p>Test execution and test result review must be independent, i.e. for any individual test case the Tester and the Test Administrator must be different individuals.</p>
-        <p>{{{data.sections.sec8s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec8s2.content}}}</td>
+            </tr>
+        </table>
         <p>The training records of all testers should be verified prior to initiating testing.</p>
     </div>
 
 
     <div class="page">
         <h2 id="section_9"><span>9</span>Traceability Matrix</h2>
-        <p>{{{data.sections.sec9.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec9.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_10"><span>10</span>Validation Environment</h2>
-        <p>{{{data.sections.sec10.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec10.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -315,17 +351,30 @@
             <li>All executed acceptance test cases</li>
             <li>Discrepancy log</li>
         </ul>
-		<p>{{{data.sections.sec12.content}}}</p>
+		<table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_13"><span>13</span>Definitions and Abbreviations</h2>
 
         <h3 id="section_13_1"><span>13.1</span>Definitions</h3>
-        <p>{{{data.sections.sec13s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec13s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+            </tr>
+        </table>
+
     </div>
 
     <div class="page">
@@ -384,7 +433,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec15.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+            </tr>
+        </table>
     </div>
 </body>
 </html>

--- a/templates/CFTP-4.html.tmpl
+++ b/templates/CFTP-4.html.tmpl
@@ -351,7 +351,7 @@
             <li>All executed acceptance test cases</li>
             <li>Discrepancy log</li>
         </ul>
-		<table>
+        <table>
             <tr>
                 <td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
             </tr>

--- a/templates/CFTP-5.html.tmpl
+++ b/templates/CFTP-5.html.tmpl
@@ -124,7 +124,11 @@
 
     <div class="page">
         <h2 id="section_2"><span>2</span>Scope</h2>
-        <p>{{{data.sections.sec2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -181,7 +185,11 @@
 
     <div class="page">
         <h2 id="section_5"><span>5</span>Operational Qualification Activities and Training</h2>
-        <p>{{{data.sections.sec5.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_5_1"><span>5.1</span>Test Procedure 1: Verification of Operational Documentation</h3>
         <p>As part of the Integration Testing the following documentation will be verified for all relevant subjects listed in the Qualification Plan.</p>
@@ -194,7 +202,11 @@
 
         <h3 id="section_5_2"><span>5.2</span>Test Procedure 2: Verification of Training Documentation</h3>
         <p>List the applicable procedures in which the Integration Testing participants must be trained before executing their portions of the Functional Testing Plan. Describe when and how the training will take place.</p>
-        <p>{{{data.sections.sec5s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s2.content}}}</td>
+            </tr>
+        </table>
         <p>Verify that an approved training plan exists, if justified, for all personnel involved in operating and maintaining the Infrastructure System.</p>
     </div>
 
@@ -205,7 +217,11 @@
         <p>The purpose of the integration testing is to verify the functional, non-functional and reliability between the modules that are integrated and work within the specifications as defined in the functional and/or configuration specifications.</p>
 
         <h3 id="section_6_2"><span>6.2</span>Scope of Integration Testing</h3>
-        <p>{{{data.sections.sec6s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -216,7 +232,11 @@
         <p>The purpose of the functional testing is to verify that the system is operational and works within the specifications as defined in the functional specifications and / or configuration specifications.</p>
 
         <h4 id="section_7_1_2"><span>7.1.2 </span>Scope of Functional Testing</h4>
-        <p>{{{data.sections.sec7s1s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7s1s2.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_7_2"><span>7.2</span>Non-Functional Testing</h3>
 
@@ -224,7 +244,11 @@
         <p>The purpose of Non-Functional testing is to check non-functional aspects (performance, usability, reliability, etc) of a software application. It is designed to test the readiness of a system as per non-functional parameters which are never addressed by functional testing.</p>
 
         <h4 id="section_7_2_2"><span>7.2.2 </span>Scope of Non-Functional Testing</h4>
-        <p>{{{data.sections.sec7s2s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7s2s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -274,19 +298,31 @@
         </ul>
 
         <p>Test execution and test result review must be independent, i.e. for any individual test case the Tester and the Test Administrator must be different individuals.</p>
-        <p>{{{data.sections.sec8s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec8s2.content}}}</td>
+            </tr>
+        </table>
         <p>The training records of all testers should be verified prior to initiating testing.</p>
     </div>
 
 
     <div class="page">
         <h2 id="section_9"><span>9</span>Traceability Matrix</h2>
-        <p>{{{data.sections.sec9.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec9.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_10"><span>10</span>Validation Environment</h2>
-        <p>{{{data.sections.sec10.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec10.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -315,17 +351,29 @@
             <li>All executed acceptance test cases</li>
             <li>Discrepancy log</li>
         </ul>
-		<p>{{{data.sections.sec12.content}}}</p>
+		<table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_13"><span>13</span>Definitions and Abbreviations</h2>
 
         <h3 id="section_13_1"><span>13.1</span>Definitions</h3>
-        <p>{{{data.sections.sec13s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec13s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -384,7 +432,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec15.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+            </tr>
+        </table>
     </div>
 </body>
 </html>

--- a/templates/CFTP-5.html.tmpl
+++ b/templates/CFTP-5.html.tmpl
@@ -351,7 +351,7 @@
             <li>All executed acceptance test cases</li>
             <li>Discrepancy log</li>
         </ul>
-		<table>
+        <table>
             <tr>
                 <td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
             </tr>

--- a/templates/CFTR-1.html.tmpl
+++ b/templates/CFTR-1.html.tmpl
@@ -107,12 +107,20 @@
 
     <div class="page">
         <h2 id="section_1"><span>1</span>Purpose</h2>
-        <p>{{{data.sections.sec1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec1.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_2"><span>2</span>Testing Environment</h2>
-        <p>{{{data.sections.sec2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -120,13 +128,25 @@
         <p>This chapter summarizes the testing activities and deliverables that were created during the testing process according to the combined functional  / requirements  testing plan of the {{metadata.name}}.</p>
 
         <h3 id="section_3_1"><span>3.1</span>Training</h3>
-        <p>{{{data.sections.sec3s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_2"><span>3.2</span>Responsibilities and Signature Resource Log</h3>
-        <p>{{{data.sections.sec3s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_3"><span>3.3</span>Discrepancy Log</h3>
-        <p>{{{data.sections.sec3s3.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s3.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_4"><span>3.4</span>Integration Testing Results</h3>
 		{{#if data.integrationTests}}
@@ -166,13 +186,21 @@
                 <p>N/A</p>
 
         <h2 id="section_3_6"><span>3.6</span>Traceability Matrix</h2>
-            <p>{{{data.sections.sec3s6.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s6.content}}}</td>
+                </tr>
+            </table>
     </div>
 
     <div class="page">
         <h2 id="section_4"><span>4</span>Risk Assessment</h2>
         <p>This section provides an assessment of all discrepancies and excluded test cases. All risks within these categories have been compiled and assessed in Appendix 1.</p>
-        <p>{{{data.sections.sec4.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec4.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -190,10 +218,18 @@
     <div class="page">
         <h2 id="section_6"><span>6</span>Definitions and Abbreviations</h2>
         <h3 id="section_6_1"><span>6.1</span>Definitions</h3>
-        <p>{{{data.sections.sec6s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_6_2"><span>6.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec6s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -203,7 +239,11 @@
             <li>Risk Assessment (version {{metadata.referencedDocs.RA}})</li>
             <li>Traceability Matrix (version {{metadata.referencedDocs.TRC}})</li>
         </ul>
-        <p>{{{data.sections.sec7.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -255,7 +295,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec8.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec8.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -346,7 +390,11 @@
 
         <h4 id="section_9_2_2"><span>9.2.2</span>Exclusions from Testing</h4>
 		N/A - all test cases without the status "Ready to Test" have been excluded from the execution.
-        <p>{{{data.sections.sec9s2s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec9s2s2.content}}}</td>
+            </tr>
+        </table>
         -->
 
         <h3 id="section_9_3"><span>9.3</span>Acceptance Testing: Failed Test Cases / Exclusions from Testing</h3>
@@ -379,7 +427,11 @@
 
 		<h4 id="section_9_3_2"><span>9.3.2</span>Exclusions from Testing</h4>
         N/A - all test cases without the status "Ready to Test" have been excluded from the execution.
-        <p>{{{data.sections.sec9s3s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec9s3s2.content}}}</td>
+            </tr>
+        </table>
         -->
     </div>
 </body>

--- a/templates/CFTR-3.html.tmpl
+++ b/templates/CFTR-3.html.tmpl
@@ -107,12 +107,20 @@
 
     <div class="page">
         <h2 id="section_1"><span>1</span>Purpose</h2>
-        <p>{{{data.sections.sec1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec1.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_2"><span>2</span>Testing Environment</h2>
-        <p>{{{data.sections.sec2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -120,13 +128,25 @@
         <p>This chapter summarizes the testing activities and deliverables that were created during the testing process according to the combined functional  / requirements  testing plan of the {{metadata.name}}.</p>
 
         <h3 id="section_3_1"><span>3.1</span>Training</h3>
-        <p>{{{data.sections.sec3s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_2"><span>3.2</span>Responsibilities and Signature Resource Log</h3>
-        <p>{{{data.sections.sec3s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_3"><span>3.3</span>Discrepancy Log</h3>
-        <p>{{{data.sections.sec3s3.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s3.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_4"><span>3.4</span>Integration Testing Results</h3>
 		<p>N/A</p>
@@ -161,16 +181,28 @@
                 <p>Additional Functional Tests not defined in Jira and executed: {{data.numAdditionalAcceptanceTests}}</p>
 
             <h4 id="section_3_5_2"><span>3.5.2 </span>Non-Functional Testing Results</h4>
-                <p>{{{data.sections.sec3s5s2.content}}}</p>
+                <table>
+                    <tr>
+                        <td class="content-wrappable">{{{data.sections.sec3s5s2.content}}}</td>
+                    </tr>
+                </table>
 
         <h2 id="section_3_6"><span>3.6</span>Traceability Matrix</h2>
-            <p>{{{data.sections.sec3s6.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s6.content}}}</td>
+                </tr>
+            </table>
     </div>
 
     <div class="page">
         <h2 id="section_4"><span>4</span>Risk Assessment</h2>
         <p>This section provides an assessment of all discrepancies and excluded test cases. All risks within these categories have been compiled and assessed in Appendix 1.</p>
-        <p>{{{data.sections.sec4.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec4.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -188,10 +220,18 @@
     <div class="page">
         <h2 id="section_6"><span>6</span>Definitions and Abbreviations</h2>
         <h3 id="section_6_1"><span>6.1</span>Definitions</h3>
-        <p>{{{data.sections.sec6s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_6_2"><span>6.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec6s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -201,7 +241,11 @@
             <li>Risk Assessment (version {{metadata.referencedDocs.RA}})</li>
             <li>Traceability Matrix (version {{metadata.referencedDocs.TRC}})</li>
         </ul>
-        <p>{{{data.sections.sec7.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -253,7 +297,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec8.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec8.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -344,7 +392,11 @@
 
         <h4 id="section_9_2_2"><span>9.2.2</span>Exclusions from Testing</h4>
 		N/A - all test cases without the status "Ready to Test" have been excluded from the execution.
-        <p>{{{data.sections.sec9s2s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec9s2s2.content}}}</td>
+            </tr>
+        </table>
         -->
 
         <h3 id="section_9_3"><span>9.3</span>Acceptance Testing: Failed Test Cases / Exclusions from Testing</h3>
@@ -377,7 +429,11 @@
 
 		<h4 id="section_9_3_2"><span>9.3.2</span>Exclusions from Testing</h4>
         N/A - all test cases without the status "Ready to Test" have been excluded from the execution.
-        <p>{{{data.sections.sec9s3s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec9s3s2.content}}}</td>
+            </tr>
+        </table>
         -->
     </div>
 </body>

--- a/templates/CFTR-4.html.tmpl
+++ b/templates/CFTR-4.html.tmpl
@@ -107,12 +107,20 @@
 
     <div class="page">
         <h2 id="section_1"><span>1</span>Purpose</h2>
-        <p>{{{data.sections.sec1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec1.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_2"><span>2</span>Testing Environment</h2>
-        <p>{{{data.sections.sec2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -120,13 +128,25 @@
         <p>This chapter summarizes the testing activities and deliverables that were created during the testing process according to the combined functional  / requirements  testing plan of the {{metadata.name}}.</p>
 
         <h3 id="section_3_1"><span>3.1</span>Training</h3>
-        <p>{{{data.sections.sec3s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_2"><span>3.2</span>Responsibilities and Signature Resource Log</h3>
-        <p>{{{data.sections.sec3s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_3"><span>3.3</span>Discrepancy Log</h3>
-        <p>{{{data.sections.sec3s3.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s3.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_4"><span>3.4</span>Integration Testing Results</h3>
 		{{#if data.integrationTests}}
@@ -188,16 +208,28 @@
                 <p>Additional Functional Tests not defined in Jira and executed: {{data.numAdditionalAcceptanceTests}}</p>
 
             <h4 id="section_3_5_2"><span>3.5.2 </span>Non-Functional Testing Results</h4>
-                <p>{{{data.sections.sec3s5s2.content}}}</p>
+                <table>
+                    <tr>
+                        <td class="content-wrappable">{{{data.sections.sec3s5s2.content}}}</td>
+                    </tr>
+                </table>
 
         <h2 id="section_3_6"><span>3.6</span>Traceability Matrix</h2>
-            <p>{{{data.sections.sec3s6.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s6.content}}}</td>
+                </tr>
+            </table>
     </div>
 
     <div class="page">
         <h2 id="section_4"><span>4</span>Risk Assessment</h2>
         <p>This section provides an assessment of all discrepancies and excluded test cases. All risks within these categories have been compiled and assessed in Appendix 1.</p>
-        <p>{{{data.sections.sec4.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec4.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -215,10 +247,18 @@
     <div class="page">
         <h2 id="section_6"><span>6</span>Definitions and Abbreviations</h2>
         <h3 id="section_6_1"><span>6.1</span>Definitions</h3>
-        <p>{{{data.sections.sec6s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_6_2"><span>6.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec6s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -228,7 +268,11 @@
             <li>Risk Assessment (version {{metadata.referencedDocs.RA}})</li>
             <li>Traceability Matrix (version {{metadata.referencedDocs.TRC}})</li>
         </ul>
-        <p>{{{data.sections.sec7.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -280,7 +324,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec8.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec8.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -371,7 +419,11 @@
 
         <h4 id="section_9_2_2"><span>9.2.2</span>Exclusions from Testing</h4>
 		N/A - all test cases without the status "Ready to Test" have been excluded from the execution.
-        <p>{{{data.sections.sec9s2s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec9s2s2.content}}}</td>
+            </tr>
+        </table>
         -->
 
         <h3 id="section_9_3"><span>9.3</span>Acceptance Testing: Failed Test Cases / Exclusions from Testing</h3>
@@ -404,7 +456,11 @@
 
 		<h4 id="section_9_3_2"><span>9.3.2</span>Exclusions from Testing</h4>
         N/A - all test cases without the status "Ready to Test" have been excluded from the execution.
-        <p>{{{data.sections.sec9s3s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec9s3s2.content}}}</td>
+            </tr>
+        </table>
         -->
     </div>
 </body>

--- a/templates/CFTR-5.html.tmpl
+++ b/templates/CFTR-5.html.tmpl
@@ -107,12 +107,20 @@
 
     <div class="page">
         <h2 id="section_1"><span>1</span>Purpose</h2>
-        <p>{{{data.sections.sec1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec1.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_2"><span>2</span>Testing Environment</h2>
-        <p>{{{data.sections.sec2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -120,13 +128,25 @@
         <p>This chapter summarizes the testing activities and deliverables that were created during the testing process according to the combined functional  / requirements  testing plan of the {{metadata.name}}.</p>
 
         <h3 id="section_3_1"><span>3.1</span>Training</h3>
-        <p>{{{data.sections.sec3s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_2"><span>3.2</span>Responsibilities and Signature Resource Log</h3>
-        <p>{{{data.sections.sec3s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_3"><span>3.3</span>Discrepancy Log</h3>
-        <p>{{{data.sections.sec3s3.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s3.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_4"><span>3.4</span>Integration Testing Results</h3>
 		{{#if data.integrationTests}}
@@ -188,16 +208,28 @@
                 <p>Additional Functional Tests not defined in Jira and executed: {{data.numAdditionalAcceptanceTests}}</p>
 
             <h4 id="section_3_5_2"><span>3.5.2 </span>Non-Functional Testing Results</h4>
-                <p>{{{data.sections.sec3s5s2.content}}}</p>
+                <table>
+                    <tr>
+                        <td class="content-wrappable">{{{data.sections.sec3s5s2.content}}}</td>
+                    </tr>
+                </table>
 
         <h2 id="section_3_6"><span>3.6</span>Traceability Matrix</h2>
-            <p>{{{data.sections.sec3s6.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s6.content}}}</td>
+                </tr>
+            </table>
     </div>
 
     <div class="page">
         <h2 id="section_4"><span>4</span>Risk Assessment</h2>
         <p>This section provides an assessment of all discrepancies and excluded test cases. All risks within these categories have been compiled and assessed in Appendix 1.</p>
-        <p>{{{data.sections.sec4.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec4.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -215,10 +247,18 @@
     <div class="page">
         <h2 id="section_6"><span>6</span>Definitions and Abbreviations</h2>
         <h3 id="section_6_1"><span>6.1</span>Definitions</h3>
-        <p>{{{data.sections.sec6s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_6_2"><span>6.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec6s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -228,7 +268,11 @@
             <li>Risk Assessment (version {{metadata.referencedDocs.RA}})</li>
             <li>Traceability Matrix (version {{metadata.referencedDocs.TRC}})</li>
         </ul>
-        <p>{{{data.sections.sec7.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -280,7 +324,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec8.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec8.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -371,7 +419,11 @@
 
         <h4 id="section_9_2_2"><span>9.2.2</span>Exclusions from Testing</h4>
 		N/A - all test cases without the status "Ready to Test" have been excluded from the execution.
-        <p>{{{data.sections.sec9s2s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec9s2s2.content}}}</td>
+            </tr>
+        </table>
         -->
 
         <h3 id="section_9_3"><span>9.3</span>Acceptance Testing: Failed Test Cases / Exclusions from Testing</h3>
@@ -404,7 +456,11 @@
 
 		<h4 id="section_9_3_2"><span>9.3.2</span>Exclusions from Testing</h4>
         N/A - all test cases without the status "Ready to Test" have been excluded from the execution.
-        <p>{{{data.sections.sec9s3s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec9s3s2.content}}}</td>
+            </tr>
+        </table>
         -->
     </div>
 </body>

--- a/templates/CSD-1.html.tmpl
+++ b/templates/CSD-1.html.tmpl
@@ -102,12 +102,20 @@
 
     <div class="page">
         <h2 id="section_1"><span>1</span>Introduction and purpose</h2>
-        <p>{{{data.sections.sec1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec1.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_2"><span>2</span>Overview</h2>
-        <p>{{{data.sections.sec2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -743,15 +751,27 @@
         <h2 id="section_5"><span>5</span>Definitions and Abbreviations</h2>
 
         <h3 id="section_5_1"><span>5.1</span>Definitions</h3>
-        <p>{{{data.sections.sec5s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_5_2"><span>5.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec5s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_6"><span>6</span>Reference Documents</h2>
-        <p>{{{data.sections.sec6.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -803,7 +823,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec7.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+            </tr>
+        </table>
     </div>
 </body>
 </html>

--- a/templates/CSD-3.html.tmpl
+++ b/templates/CSD-3.html.tmpl
@@ -102,12 +102,20 @@
 
     <div class="page">
         <h2 id="section_1"><span>1</span>Introduction and purpose</h2>
-        <p>{{{data.sections.sec1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec1.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_2"><span>2</span>Overview</h2>
-        <p>{{{data.sections.sec2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -115,10 +123,18 @@
         <p>Requirements intended to fulfil applicable regulatory requirements are included in the tables below.</p>
 
         <h3 id="section_3_1"><span>3.1</span>Related Business / GxP Process</h3>
-        <p>{{{data.sections.sec3s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_2"><span>3.2</span>Operational Requirements</h3>
-        <p>{{{data.sections.sec3s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+            </tr>
+        </table>
         <p>Requirements intended to fulfil applicable regulatory requirements are included in the tables below.</p>
 
             {{#if data.requirements.operationalrequirements.noepics}}
@@ -678,15 +694,27 @@
         <h2 id="section_5"><span>5</span>Definitions and Abbreviations</h2>
 
         <h3 id="section_5_1"><span>5.1</span>Definitions</h3>
-        <p>{{{data.sections.sec5s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_5_2"><span>5.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec5s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_6"><span>6</span>Reference Documents</h2>
-        <p>{{{data.sections.sec6.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -738,7 +766,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec7.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+            </tr>
+        </table>
     </div>
 </body>
 </html>

--- a/templates/CSD-4.html.tmpl
+++ b/templates/CSD-4.html.tmpl
@@ -102,12 +102,20 @@
 
     <div class="page">
         <h2 id="section_1"><span>1</span>Introduction and purpose</h2>
-        <p>{{{data.sections.sec1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec1.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_2"><span>2</span>Overview</h2>
-        <p>{{{data.sections.sec2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -115,10 +123,18 @@
         <p>Requirements intended to fulfil applicable regulatory requirements are included in the tables below.</p>
 
         <h3 id="section_3_1"><span>3.1</span>Related Business / GxP Process</h3>
-        <p>{{{data.sections.sec3s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_2"><span>3.2</span>Operational Requirements</h3>
-        <p>{{{data.sections.sec3s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+            </tr>
+        </table>
         <p>Requirements intended to fulfil applicable regulatory requirements are included in the tables below.</p>
 
             {{#if data.requirements.operationalrequirements.noepics}}
@@ -920,15 +936,27 @@
         <h2 id="section_5"><span>5</span>Definitions and Abbreviations</h2>
 
         <h3 id="section_5_1"><span>5.1</span>Definitions</h3>
-        <p>{{{data.sections.sec5s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_5_2"><span>5.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec5s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_6"><span>6</span>Reference Documents</h2>
-        <p>{{{data.sections.sec6.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -980,7 +1008,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec7.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+            </tr>
+        </table>
     </div>
 </body>
 </html>

--- a/templates/CSD-5.html.tmpl
+++ b/templates/CSD-5.html.tmpl
@@ -102,12 +102,20 @@
 
     <div class="page">
         <h2 id="section_1"><span>1</span>Introduction and purpose</h2>
-        <p>{{{data.sections.sec1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec1.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_2"><span>2</span>Overview</h2>
-        <p>{{{data.sections.sec2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -115,10 +123,18 @@
         <p>Requirements intended to fulfil applicable regulatory requirements are included in the tables below.</p>
 
         <h3 id="section_3_1"><span>3.1</span>Related Business / GxP Process</h3>
-        <p>{{{data.sections.sec3s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_2"><span>3.2</span>Operational Requirements</h3>
-        <p>{{{data.sections.sec3s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+            </tr>
+        </table>
         <p>Requirements intended to fulfil applicable regulatory requirements are included in the tables below.</p>
 
             {{#if data.requirements.operationalrequirements.noepics}}
@@ -1181,15 +1197,27 @@
         <h2 id="section_5"><span>5</span>Definitions and Abbreviations</h2>
 
         <h3 id="section_5_1"><span>5.1</span>Definitions</h3>
-        <p>{{{data.sections.sec5s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_5_2"><span>5.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec5s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_6"><span>6</span>Reference Documents</h2>
-        <p>{{{data.sections.sec6.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -1241,7 +1269,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec7.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+            </tr>
+        </table>
     </div>
 </body>
 </html>

--- a/templates/DTP.html.tmpl
+++ b/templates/DTP.html.tmpl
@@ -204,10 +204,18 @@
         <h2 id="section_5"><span>5</span>Definitions and Abbreviations</h2>
 
         <h3 id="section_5_1"><span>5.1</span>Definitions</h3>
-        <p>{{{data.sections.sec5s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_5_2"><span>5.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec5s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -217,7 +225,11 @@
             <li>System and Software Design Specification including Source Code Review Plan (version {{metadata.referencedDocs.SSDS}})</li>
             <li>Risk Assessment (version {{metadata.referencedDocs.RA}})</li>
         </ul>
-        <p>{{{data.sections.sec6.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -269,7 +281,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec7.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+            </tr>
+        </table>
     </div>
 </body>
 </html>

--- a/templates/DTR.html.tmpl
+++ b/templates/DTR.html.tmpl
@@ -170,10 +170,19 @@
     <div class="page">
         <h2 id="section_5"><span>5</span>Definitions and Abbreviations</h2>
         <h3 id="section_5_1"><span>5.1</span>Definitions</h3>
-        <p>{{{data.sections.sec5s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_5_2"><span>5.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec5s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s2.content}}}</td>
+            </tr>
+        </table>
+
     </div>
 
     <div class="page">
@@ -185,7 +194,11 @@
             <li>Risk Assessment (version {{metadata.referencedDocs.RA}})</li>
             <li>Software Development Testing Plan (version {{metadata.referencedDocs.DTP}})</li>
         </ul>
-        <p>{{{data.sections.sec6.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -237,7 +250,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec7.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">

--- a/templates/RA.html.tmpl
+++ b/templates/RA.html.tmpl
@@ -118,7 +118,11 @@
 
     <div class="page">
         <h2 id="section_3"><span>3</span>Assumptions</h2>
-        <p>{{{data.sections.sec3.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -436,10 +440,18 @@
     <div class="page">
         <h2 id="section_6"><span>6</span>Definitions and Abbreviations</h2>
         <h3 id="section_6_1"><span>6.1</span>Definitions</h3>
-		<p>{{{data.sections.sec6s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+            </tr>
+        </table>
 
 		<h3 id="section_6_2"><span>6.2</span>Abbreviations</h3>
-		<p>{{{data.sections.sec6s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -449,7 +461,11 @@
             <li>System and Software Design Specification including Source Code Review Plan (version {{metadata.referencedDocs.SSDS}})</li>
             <li>Functional and Requirements Testing Plan (version {{metadata.referencedDocs.CFTP}})</li>
         </ul>
-        <p>{{{data.sections.sec7.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+            </tr>
+        </table>
     </div>
 
 	<div class="page">
@@ -501,7 +517,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec8.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec8.content}}}</td>
+            </tr>
+        </table>
     </div>
 </body>
 </html>

--- a/templates/RA.html.tmpl
+++ b/templates/RA.html.tmpl
@@ -446,7 +446,7 @@
             </tr>
         </table>
 
-		<h3 id="section_6_2"><span>6.2</span>Abbreviations</h3>
+        <h3 id="section_6_2"><span>6.2</span>Abbreviations</h3>
         <table>
             <tr>
                 <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>

--- a/templates/SSDS-1.html.tmpl
+++ b/templates/SSDS-1.html.tmpl
@@ -123,10 +123,10 @@
 
 			<h3 id="section_2_1"><span>2.1</span>System Design Overview incl. System Diagram</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_2_2"><span>2.2</span>Software Design Overview</h3>
 			<p>N/A</p>
@@ -186,18 +186,18 @@
 			{{/if}}
 
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+				</tr>
+			</table>
 
 
 			<h3 id="section_3_2"><span>3.2</span>System Description</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+				</tr>
+			</table>
 
 			<h4><span>3.2.1</span> Modules to be developed</h4>
 			<p>N/A</p>
@@ -272,19 +272,19 @@
 			{{/if}}
 
 			<h3 id="section_5_3"><span>5.3</span>Utilisation of Existing Infrastructure Systems</h3>
-            <table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
-                </tr>
-            </table>
+			<table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
+				</tr>
+			</table>
 
 
 			<h3 id="section_5_4"><span>5.4</span>Utilisation of Existing Infrastructure Services</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
@@ -292,33 +292,33 @@
 
 			<h3 id="section_6_1"><span>6.1</span>Development Environment</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_6_2"><span>6.2</span>QA/Test Environment</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_6_3"><span>6.3</span>Training Environment</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_7"><span>7</span>Environmental Conditions</h2>
-            <table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
-                </tr>
-            </table>
+			<table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
@@ -370,16 +370,16 @@
 			<h2 id="section_13"><span>13</span>Definitions And Abbreviations</h2>
 			<h3 id="section_13_1"><span>13.1</span>Definitions</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+				</tr>
+			</table>
 			<h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
@@ -392,11 +392,11 @@
 				{{/each}}
 			    {{/if}}
 			</ul>
-            <table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec14.content}}}</td>
-                </tr>
-            </table>
+			<table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec14.content}}}</td>
+				</tr>
+			</table>
 		</div>
 		<div class="page">
 			<h2 id="section_15"><span>15</span>Document History</h2>
@@ -448,10 +448,10 @@
             </table>
             {{/if}}
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 	</body>

--- a/templates/SSDS-1.html.tmpl
+++ b/templates/SSDS-1.html.tmpl
@@ -122,7 +122,11 @@
 			<h2 id="section_2"><span>2</span>Overview</h2>
 
 			<h3 id="section_2_1"><span>2.1</span>System Design Overview incl. System Diagram</h3>
-			<p>{{{data.sections.sec2s1.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_2_2"><span>2.2</span>Software Design Overview</h3>
 			<p>N/A</p>
@@ -147,7 +151,12 @@
                 <li>INFO - Neither a bug nor a quality flaw, just a finding.</li>
             </ul>
 
-        <p>{{{data.sections.sec2s3.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2s3.content}}}</td>
+            </tr>
+        </table>
+
 
 		</div>
 
@@ -176,10 +185,20 @@
 			<p><em>N/A</em></p>
 			{{/if}}
 
-			<p>{{{data.sections.sec3s1.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+                </tr>
+            </table>
+
 
 			<h3 id="section_3_2"><span>3.2</span>System Description</h3>
-			<p>{{{data.sections.sec3s2.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+                </tr>
+            </table>
+
 			<h4><span>3.2.1</span> Modules to be developed</h4>
 			<p>N/A</p>
 
@@ -253,28 +272,53 @@
 			{{/if}}
 
 			<h3 id="section_5_3"><span>5.3</span>Utilisation of Existing Infrastructure Systems</h3>
-			<p>{{{data.sections.sec5s3.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
+                </tr>
+            </table>
+
 
 			<h3 id="section_5_4"><span>5.4</span>Utilisation of Existing Infrastructure Services</h3>
-			<p>{{{data.sections.sec5s4.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_6"><span>6</span>Configurations for Additional Environments</h2>
 
 			<h3 id="section_6_1"><span>6.1</span>Development Environment</h3>
-			<p>{{{data.sections.sec6s1.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_6_2"><span>6.2</span>QA/Test Environment</h3>
-			<p>{{{data.sections.sec6s2.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_6_3"><span>6.3</span>Training Environment</h3>
-			<p>{{{data.sections.sec6s3.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_7"><span>7</span>Environmental Conditions</h2>
-			<p>{{{data.sections.sec7.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
@@ -325,9 +369,17 @@
 		<div class="page">
 			<h2 id="section_13"><span>13</span>Definitions And Abbreviations</h2>
 			<h3 id="section_13_1"><span>13.1</span>Definitions</h3>
-			<p>{{{data.sections.sec13s1.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+                </tr>
+            </table>
 			<h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
-			<p>{{{data.sections.sec13s2.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
@@ -340,7 +392,11 @@
 				{{/each}}
 			    {{/if}}
 			</ul>
-            <p>{{{data.sections.sec14.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec14.content}}}</td>
+                </tr>
+            </table>
 		</div>
 		<div class="page">
 			<h2 id="section_15"><span>15</span>Document History</h2>
@@ -391,7 +447,11 @@
                 {{/each}}
             </table>
             {{/if}}
-			<p>{{{data.sections.sec15.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 	</body>

--- a/templates/SSDS-1.html.tmpl
+++ b/templates/SSDS-1.html.tmpl
@@ -123,9 +123,9 @@
 
 			<h3 id="section_2_1"><span>2.1</span>System Design Overview incl. System Diagram</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_2_2"><span>2.2</span>Software Design Overview</h3>
@@ -186,17 +186,17 @@
 			{{/if}}
 
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+			    </tr>
 			</table>
 
 
 			<h3 id="section_3_2"><span>3.2</span>System Description</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+			    </tr>
 			</table>
 
 			<h4><span>3.2.1</span> Modules to be developed</h4>
@@ -273,17 +273,17 @@
 
 			<h3 id="section_5_3"><span>5.3</span>Utilisation of Existing Infrastructure Systems</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
+			    </tr>
 			</table>
 
 
 			<h3 id="section_5_4"><span>5.4</span>Utilisation of Existing Infrastructure Services</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
@@ -292,32 +292,32 @@
 
 			<h3 id="section_6_1"><span>6.1</span>Development Environment</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_6_2"><span>6.2</span>QA/Test Environment</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_6_3"><span>6.3</span>Training Environment</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_7"><span>7</span>Environmental Conditions</h2>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
@@ -370,15 +370,15 @@
 			<h2 id="section_13"><span>13</span>Definitions And Abbreviations</h2>
 			<h3 id="section_13_1"><span>13.1</span>Definitions</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+			    </tr>
 			</table>
 			<h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
@@ -393,9 +393,9 @@
 			    {{/if}}
 			</ul>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec14.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec14.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 		<div class="page">
@@ -448,9 +448,9 @@
             </table>
             {{/if}}
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 

--- a/templates/SSDS-3.html.tmpl
+++ b/templates/SSDS-3.html.tmpl
@@ -122,7 +122,11 @@
 			<h2 id="section_2"><span>2</span>Overview</h2>
 
 			<h3 id="section_2_1"><span>2.1</span>System Design Overview incl. System Diagram</h3>
-			<p>{{{data.sections.sec2s1.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_2_2"><span>2.2</span>Software Design Overview</h3>
 			<p>N/A</p>
@@ -147,7 +151,11 @@
                 <li>INFO - Neither a bug nor a quality flaw, just a finding.</li>
             </ul>
 
-        <p>{{{data.sections.sec2s3.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2s3.content}}}</td>
+            </tr>
+        </table>
 
 		</div>
 
@@ -176,10 +184,18 @@
 			<p><em>N/A</em></p>
 			{{/if}}
 
-			<p>{{{data.sections.sec3s1.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_3_2"><span>3.2</span>System Description</h3>
-			<p>{{{data.sections.sec3s2.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+                </tr>
+            </table>
 			<h4><span>3.2.1</span> Modules to be developed</h4>
 			<p>N/A</p>
 
@@ -253,28 +269,52 @@
 			{{/if}}
 
 			<h3 id="section_5_3"><span>5.3</span>Utilisation of Existing Infrastructure Systems</h3>
-			<p>{{{data.sections.sec5s3.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_5_4"><span>5.4</span>Utilisation of Existing Infrastructure Services</h3>
-			<p>{{{data.sections.sec5s4.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_6"><span>6</span>Configurations for Additional Environments</h2>
 
 			<h3 id="section_6_1"><span>6.1</span>Development Environment</h3>
-			<p>{{{data.sections.sec6s1.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_6_2"><span>6.2</span>QA/Test Environment</h3>
-			<p>{{{data.sections.sec6s2.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_6_3"><span>6.3</span>Training Environment</h3>
-			<p>{{{data.sections.sec6s3.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_7"><span>7</span>Environmental Conditions</h2>
-			<p>{{{data.sections.sec7.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
@@ -325,9 +365,18 @@
 		<div class="page">
 			<h2 id="section_13"><span>13</span>Definitions And Abbreviations</h2>
 			<h3 id="section_13_1"><span>13.1</span>Definitions</h3>
-			<p>{{{data.sections.sec13s1.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+                </tr>
+            </table>
+
 			<h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
-			<p>{{{data.sections.sec13s2.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
@@ -340,7 +389,11 @@
 				{{/each}}
 			    {{/if}}
 			</ul>
-            <p>{{{data.sections.sec14.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec14.content}}}</td>
+                </tr>
+            </table>
 		</div>
 		<div class="page">
 			<h2 id="section_15"><span>15</span>Document History</h2>
@@ -391,7 +444,11 @@
                 {{/each}}
             </table>
             {{/if}}
-			<p>{{{data.sections.sec15.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 	</body>

--- a/templates/SSDS-3.html.tmpl
+++ b/templates/SSDS-3.html.tmpl
@@ -122,11 +122,11 @@
 			<h2 id="section_2"><span>2</span>Overview</h2>
 
 			<h3 id="section_2_1"><span>2.1</span>System Design Overview incl. System Diagram</h3>
-            <table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
-                </tr>
-            </table>
+			<table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_2_2"><span>2.2</span>Software Design Overview</h3>
 			<p>N/A</p>
@@ -185,17 +185,17 @@
 			{{/if}}
 
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_3_2"><span>3.2</span>System Description</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+				</tr>
+			</table>
 			<h4><span>3.2.1</span> Modules to be developed</h4>
 			<p>N/A</p>
 
@@ -269,18 +269,18 @@
 			{{/if}}
 
 			<h3 id="section_5_3"><span>5.3</span>Utilisation of Existing Infrastructure Systems</h3>
-            <table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
-                </tr>
-            </table>
+			<table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_5_4"><span>5.4</span>Utilisation of Existing Infrastructure Services</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
@@ -288,33 +288,33 @@
 
 			<h3 id="section_6_1"><span>6.1</span>Development Environment</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_6_2"><span>6.2</span>QA/Test Environment</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_6_3"><span>6.3</span>Training Environment</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_7"><span>7</span>Environmental Conditions</h2>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
@@ -366,17 +366,17 @@
 			<h2 id="section_13"><span>13</span>Definitions And Abbreviations</h2>
 			<h3 id="section_13_1"><span>13.1</span>Definitions</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
@@ -445,10 +445,10 @@
             </table>
             {{/if}}
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 	</body>

--- a/templates/SSDS-3.html.tmpl
+++ b/templates/SSDS-3.html.tmpl
@@ -123,9 +123,9 @@
 
 			<h3 id="section_2_1"><span>2.1</span>System Design Overview incl. System Diagram</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_2_2"><span>2.2</span>Software Design Overview</h3>
@@ -185,16 +185,16 @@
 			{{/if}}
 
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_3_2"><span>3.2</span>System Description</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+			    </tr>
 			</table>
 			<h4><span>3.2.1</span> Modules to be developed</h4>
 			<p>N/A</p>
@@ -270,16 +270,16 @@
 
 			<h3 id="section_5_3"><span>5.3</span>Utilisation of Existing Infrastructure Systems</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_5_4"><span>5.4</span>Utilisation of Existing Infrastructure Services</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
@@ -288,32 +288,32 @@
 
 			<h3 id="section_6_1"><span>6.1</span>Development Environment</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_6_2"><span>6.2</span>QA/Test Environment</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_6_3"><span>6.3</span>Training Environment</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_7"><span>7</span>Environmental Conditions</h2>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
@@ -366,16 +366,16 @@
 			<h2 id="section_13"><span>13</span>Definitions And Abbreviations</h2>
 			<h3 id="section_13_1"><span>13.1</span>Definitions</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
@@ -445,9 +445,9 @@
             </table>
             {{/if}}
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 

--- a/templates/SSDS-4.html.tmpl
+++ b/templates/SSDS-4.html.tmpl
@@ -122,8 +122,11 @@
 			<h2 id="section_2"><span>2</span>Overview</h2>
 
 			<h3 id="section_2_1"><span>2.1</span>System Design Overview incl. System Diagram</h3>
-			<p>{{{data.sections.sec2s1.content}}}</p>
-
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
+                </tr>
+            </table>
 			<h3 id="section_2_2"><span>2.2</span>Software Design Overview</h3>
 			<p>N/A</p>
 
@@ -147,8 +150,11 @@
                 <li>INFO - Neither a bug nor a quality flaw, just a finding.</li>
             </ul>
 
-        <p>{{{data.sections.sec2s3.content}}}</p>
-
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2s3.content}}}</td>
+            </tr>
+        </table>
 		</div>
 
 		<div class="page">
@@ -176,10 +182,18 @@
 			<p><em>N/A</em></p>
 			{{/if}}
 
-			<p>{{{data.sections.sec3s1.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_3_2"><span>3.2</span>System Description</h3>
-			<p>{{{data.sections.sec3s2.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+                </tr>
+            </table>
 			<h4><span>3.2.1</span> Modules to be developed</h4>
 			<p>N/A</p>
 
@@ -253,28 +267,52 @@
 			{{/if}}
 
 			<h3 id="section_5_3"><span>5.3</span>Utilisation of Existing Infrastructure Systems</h3>
-			<p>{{{data.sections.sec5s3.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_5_4"><span>5.4</span>Utilisation of Existing Infrastructure Services</h3>
-			<p>{{{data.sections.sec5s4.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_6"><span>6</span>Configurations for Additional Environments</h2>
 
 			<h3 id="section_6_1"><span>6.1</span>Development Environment</h3>
-			<p>{{{data.sections.sec6s1.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_6_2"><span>6.2</span>QA/Test Environment</h3>
-			<p>{{{data.sections.sec6s2.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_6_3"><span>6.3</span>Training Environment</h3>
-			<p>{{{data.sections.sec6s3.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_7"><span>7</span>Environmental Conditions</h2>
-			<p>{{{data.sections.sec7.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
@@ -325,9 +363,17 @@
 		<div class="page">
 			<h2 id="section_13"><span>13</span>Definitions And Abbreviations</h2>
 			<h3 id="section_13_1"><span>13.1</span>Definitions</h3>
-			<p>{{{data.sections.sec13s1.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+                </tr>
+            </table>
 			<h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
-			<p>{{{data.sections.sec13s2.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
@@ -340,7 +386,11 @@
 				{{/each}}
 			    {{/if}}
 			</ul>
-            <p>{{{data.sections.sec14.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec14.content}}}</td>
+                </tr>
+            </table>
 		</div>
 		<div class="page">
 			<h2 id="section_15"><span>15</span>Document History</h2>
@@ -391,7 +441,11 @@
                 {{/each}}
             </table>
             {{/if}}
-			<p>{{{data.sections.sec15.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 	</body>

--- a/templates/SSDS-4.html.tmpl
+++ b/templates/SSDS-4.html.tmpl
@@ -123,9 +123,9 @@
 
 			<h3 id="section_2_1"><span>2.1</span>System Design Overview incl. System Diagram</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
+			    </tr>
 			</table>
 			<h3 id="section_2_2"><span>2.2</span>Software Design Overview</h3>
 			<p>N/A</p>
@@ -184,16 +184,16 @@
 			{{/if}}
 
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_3_2"><span>3.2</span>System Description</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+			    </tr>
 			</table>
 			<h4><span>3.2.1</span> Modules to be developed</h4>
 			<p>N/A</p>
@@ -269,16 +269,16 @@
 
 			<h3 id="section_5_3"><span>5.3</span>Utilisation of Existing Infrastructure Systems</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_5_4"><span>5.4</span>Utilisation of Existing Infrastructure Services</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
@@ -287,32 +287,32 @@
 
 			<h3 id="section_6_1"><span>6.1</span>Development Environment</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_6_2"><span>6.2</span>QA/Test Environment</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_6_3"><span>6.3</span>Training Environment</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_7"><span>7</span>Environmental Conditions</h2>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
@@ -365,15 +365,15 @@
 			<h2 id="section_13"><span>13</span>Definitions And Abbreviations</h2>
 			<h3 id="section_13_1"><span>13.1</span>Definitions</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+			    </tr>
 			</table>
 			<h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 

--- a/templates/SSDS-4.html.tmpl
+++ b/templates/SSDS-4.html.tmpl
@@ -123,10 +123,10 @@
 
 			<h3 id="section_2_1"><span>2.1</span>System Design Overview incl. System Diagram</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
+				</tr>
+			</table>
 			<h3 id="section_2_2"><span>2.2</span>Software Design Overview</h3>
 			<p>N/A</p>
 
@@ -155,6 +155,7 @@
                 <td class="content-wrappable">{{{data.sections.sec2s3.content}}}</td>
             </tr>
         </table>
+
 		</div>
 
 		<div class="page">
@@ -182,18 +183,18 @@
 			<p><em>N/A</em></p>
 			{{/if}}
 
-            <table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
-                </tr>
-            </table>
+			<table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_3_2"><span>3.2</span>System Description</h3>
-            <table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
-                </tr>
-            </table>
+			<table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+				</tr>
+			</table>
 			<h4><span>3.2.1</span> Modules to be developed</h4>
 			<p>N/A</p>
 
@@ -268,51 +269,51 @@
 
 			<h3 id="section_5_3"><span>5.3</span>Utilisation of Existing Infrastructure Systems</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_5_4"><span>5.4</span>Utilisation of Existing Infrastructure Services</h3>
-            <table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
-                </tr>
-            </table>
+			<table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_6"><span>6</span>Configurations for Additional Environments</h2>
 
 			<h3 id="section_6_1"><span>6.1</span>Development Environment</h3>
-            <table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
-                </tr>
-            </table>
+			<table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_6_2"><span>6.2</span>QA/Test Environment</h3>
-            <table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
-                </tr>
-            </table>
+			<table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_6_3"><span>6.3</span>Training Environment</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_7"><span>7</span>Environmental Conditions</h2>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
@@ -364,16 +365,16 @@
 			<h2 id="section_13"><span>13</span>Definitions And Abbreviations</h2>
 			<h3 id="section_13_1"><span>13.1</span>Definitions</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+				</tr>
+			</table>
 			<h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
-            <table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
-                </tr>
-            </table>
+			<table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">

--- a/templates/SSDS-5.html.tmpl
+++ b/templates/SSDS-5.html.tmpl
@@ -122,10 +122,18 @@
 			<h2 id="section_2"><span>2</span>Overview</h2>
 
 			<h3 id="section_2_1"><span>2.1</span>System Design Overview incl. System Diagram</h3>
-			<p>{{{data.sections.sec2s1.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_2_2"><span>2.2</span>Software Design Overview</h3>
-			<p>{{{data.sections.sec2s2.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec2s2.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_2_3"><span>2.3</span>Source Code Review Overview</h3>
             <p>The scope of the automated review, performed by SonarQube, during the build process, is all modules listed below, based on defined quality rule sets (Quality Profiles).<br>The installation of SonarQube is part of OpenDevStack (<em>BI-IT-DEVSTACK</em>) and hence qualified.</p>
@@ -147,7 +155,11 @@
                 <li>INFO - Neither a bug nor a quality flaw, just a finding.</li>
             </ul>
 
-        <p>{{{data.sections.sec2s3.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec2s3.content}}}</td>
+            </tr>
+        </table>
 
 		</div>
 
@@ -176,10 +188,18 @@
 			<p><em>N/A</em></p>
 			{{/if}}
 
-			<p>{{{data.sections.sec3s1.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_3_2"><span>3.2</span>System Description</h3>
-			<p>{{{data.sections.sec3s2.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+                </tr>
+            </table>
 			<h4><span>3.2.1</span> Modules to be developed</h4>
 			<!-- all data for sec10 is contained in sec5s1 already -->
 			{{#if data.sections.sec10.modules}}
@@ -201,9 +221,17 @@
 			{{/if}}
 
 			<h4><span>3.2.2</span> Interfaces between Modules</h4>
-			<p>{{{data.sections.sec3s2s2.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s2s2.content}}}</td>
+                </tr>
+            </table>
 			<h4><span>3.2.3</span> Interfaces to External Systems</h4>
-			<p>{{{data.sections.sec3s2s3.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec3s2s3.content}}}</td>
+                </tr>
+            </table>
 			<h4><span>3.2.4</span> System Diagram</h4>
 			{{{data.sections.sec3s2s4.content}}}
 		</div>
@@ -270,38 +298,70 @@
 			{{/if}}
 
 			<h3 id="section_5_3"><span>5.3</span>Utilisation of Existing Infrastructure Systems</h3>
-			<p>{{{data.sections.sec5s3.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_5_4"><span>5.4</span>Utilisation of Existing Infrastructure Services</h3>
-			<p>{{{data.sections.sec5s4.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_6"><span>6</span>Configurations for Additional Environments</h2>
 
 			<h3 id="section_6_1"><span>6.1</span>Development Environment</h3>
-			<p>{{{data.sections.sec6s1.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_6_2"><span>6.2</span>QA/Test Environment</h3>
-			<p>{{{data.sections.sec6s2.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+                </tr>
+            </table>
 
 			<h3 id="section_6_3"><span>6.3</span>Training Environment</h3>
-			<p>{{{data.sections.sec6s3.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_7"><span>7</span>Environmental Conditions</h2>
-			<p>{{{data.sections.sec7.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_8"><span>8</span>Software Design Principles</h2>
-			<p>{{{data.sections.sec8.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec8.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_9"><span>9</span>System Data</h2>
-			<p>{{{data.sections.sec9.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec9.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
@@ -400,16 +460,28 @@
             </ul>
             {{/if}}
 
-			<p>{{{data.sections.sec12.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
+                </tr>
+            </table>
 
 		</div>
 
 		<div class="page">
 			<h2 id="section_13"><span>13</span>Definitions And Abbreviations</h2>
 			<h3 id="section_13_1"><span>13.1</span>Definitions</h3>
-			<p>{{{data.sections.sec13s1.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+                </tr>
+            </table>
 			<h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
-			<p>{{{data.sections.sec13s2.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 		<div class="page">
@@ -417,7 +489,12 @@
 			<ul>
                 <li>Combined Specification Document (version {{metadata.referencedDocs.CSD}})</li>
 			</ul>
-            <p>{{{data.sections.sec14.content}}}</p>
+            <table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec14.content}}}</td>
+                </tr>
+            </table>
+
 		</div>
 		<div class="page">
 			<h2 id="section_15"><span>15</span>Document History</h2>
@@ -468,7 +545,11 @@
                 {{/each}}
             </table>
             {{/if}}
-			<p>{{{data.sections.sec15.content}}}</p>
+			<table>
+                <tr>
+                    <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+                </tr>
+            </table>
 		</div>
 
 	</body>

--- a/templates/SSDS-5.html.tmpl
+++ b/templates/SSDS-5.html.tmpl
@@ -123,16 +123,16 @@
 
 			<h3 id="section_2_1"><span>2.1</span>System Design Overview incl. System Diagram</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_2_2"><span>2.2</span>Software Design Overview</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec2s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec2s2.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_2_3"><span>2.3</span>Source Code Review Overview</h3>
@@ -189,16 +189,16 @@
 			{{/if}}
 
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_3_2"><span>3.2</span>System Description</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+			    </tr>
 			</table>
 			<h4><span>3.2.1</span> Modules to be developed</h4>
 			<!-- all data for sec10 is contained in sec5s1 already -->
@@ -222,15 +222,15 @@
 
 			<h4><span>3.2.2</span> Interfaces between Modules</h4>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec3s2s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec3s2s2.content}}}</td>
+			    </tr>
 			</table>
 			<h4><span>3.2.3</span> Interfaces to External Systems</h4>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec3s2s3.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec3s2s3.content}}}</td>
+			    </tr>
 			</table>
 			<h4><span>3.2.4</span> System Diagram</h4>
 			{{{data.sections.sec3s2s4.content}}}
@@ -299,16 +299,16 @@
 
 			<h3 id="section_5_3"><span>5.3</span>Utilisation of Existing Infrastructure Systems</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_5_4"><span>5.4</span>Utilisation of Existing Infrastructure Services</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
@@ -317,50 +317,50 @@
 
 			<h3 id="section_6_1"><span>6.1</span>Development Environment</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_6_2"><span>6.2</span>QA/Test Environment</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+			    </tr>
 			</table>
 
 			<h3 id="section_6_3"><span>6.3</span>Training Environment</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_7"><span>7</span>Environmental Conditions</h2>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_8"><span>8</span>Software Design Principles</h2>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec8.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec8.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_9"><span>9</span>System Data</h2>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec9.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec9.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
@@ -461,9 +461,9 @@
             {{/if}}
 
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
+			    </tr>
 			</table>
 
 		</div>
@@ -472,15 +472,15 @@
 			<h2 id="section_13"><span>13</span>Definitions And Abbreviations</h2>
 			<h3 id="section_13_1"><span>13.1</span>Definitions</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+			    </tr>
 			</table>
 			<h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 
@@ -546,9 +546,9 @@
             </table>
             {{/if}}
 			<table>
-				<tr>
-					<td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
-				</tr>
+			    <tr>
+			        <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+			    </tr>
 			</table>
 		</div>
 

--- a/templates/SSDS-5.html.tmpl
+++ b/templates/SSDS-5.html.tmpl
@@ -123,17 +123,17 @@
 
 			<h3 id="section_2_1"><span>2.1</span>System Design Overview incl. System Diagram</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec2s1.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_2_2"><span>2.2</span>Software Design Overview</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec2s2.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec2s2.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_2_3"><span>2.3</span>Source Code Review Overview</h3>
             <p>The scope of the automated review, performed by SonarQube, during the build process, is all modules listed below, based on defined quality rule sets (Quality Profiles).<br>The installation of SonarQube is part of OpenDevStack (<em>BI-IT-DEVSTACK</em>) and hence qualified.</p>
@@ -189,17 +189,17 @@
 			{{/if}}
 
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec3s1.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_3_2"><span>3.2</span>System Description</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec3s2.content}}}</td>
+				</tr>
+			</table>
 			<h4><span>3.2.1</span> Modules to be developed</h4>
 			<!-- all data for sec10 is contained in sec5s1 already -->
 			{{#if data.sections.sec10.modules}}
@@ -221,17 +221,17 @@
 			{{/if}}
 
 			<h4><span>3.2.2</span> Interfaces between Modules</h4>
-            <table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec3s2s2.content}}}</td>
-                </tr>
-            </table>
+			<table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec3s2s2.content}}}</td>
+				</tr>
+			</table>
 			<h4><span>3.2.3</span> Interfaces to External Systems</h4>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec3s2s3.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec3s2s3.content}}}</td>
+				</tr>
+			</table>
 			<h4><span>3.2.4</span> System Diagram</h4>
 			{{{data.sections.sec3s2s4.content}}}
 		</div>
@@ -299,17 +299,17 @@
 
 			<h3 id="section_5_3"><span>5.3</span>Utilisation of Existing Infrastructure Systems</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec5s3.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_5_4"><span>5.4</span>Utilisation of Existing Infrastructure Services</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec5s4.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
@@ -317,51 +317,51 @@
 
 			<h3 id="section_6_1"><span>6.1</span>Development Environment</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec6s1.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_6_2"><span>6.2</span>QA/Test Environment</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec6s2.content}}}</td>
+				</tr>
+			</table>
 
 			<h3 id="section_6_3"><span>6.3</span>Training Environment</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec6s3.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_7"><span>7</span>Environmental Conditions</h2>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_8"><span>8</span>Software Design Principles</h2>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec8.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec8.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
 			<h2 id="section_9"><span>9</span>System Data</h2>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec9.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec9.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
@@ -461,10 +461,10 @@
             {{/if}}
 
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
+				</tr>
+			</table>
 
 		</div>
 
@@ -472,16 +472,16 @@
 			<h2 id="section_13"><span>13</span>Definitions And Abbreviations</h2>
 			<h3 id="section_13_1"><span>13.1</span>Definitions</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec13s1.content}}}</td>
+				</tr>
+			</table>
 			<h3 id="section_13_2"><span>13.2</span>Abbreviations</h3>
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec13s2.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 		<div class="page">
@@ -546,10 +546,10 @@
             </table>
             {{/if}}
 			<table>
-                <tr>
-                    <td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
-                </tr>
-            </table>
+				<tr>
+					<td class="content-wrappable">{{{data.sections.sec15.content}}}</td>
+				</tr>
+			</table>
 		</div>
 
 	</body>

--- a/templates/TCP.html.tmpl
+++ b/templates/TCP.html.tmpl
@@ -131,7 +131,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec1.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">

--- a/templates/TCR.html.tmpl
+++ b/templates/TCR.html.tmpl
@@ -140,7 +140,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec1.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">

--- a/templates/TIP.html.tmpl
+++ b/templates/TIP.html.tmpl
@@ -229,7 +229,11 @@
         </table>
 
         <h3 id="section_3_4"><span>3.4</span>Communication and Organization Tasks</h3>
-        <p>{{{data.sections.sec3s4.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3s4.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_3_5"><span>3.5</span>Back Out Plan</h3>
         <p>In case the installation of the component fails, the component will be rolled back to its previous working version. This is a standard feature of the underlying qualified platform.</p>
@@ -292,10 +296,18 @@
         <h2 id="section_10"><span>10</span>Definitions and Abbreviations</h2>
 
         <h3 id="section_10_1"><span>10.1</span>Definitions</h3>
-        <p>{{{data.sections.sec10s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec10s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_10_2"><span>10.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec10s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec10s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -303,7 +315,11 @@
         <ul>
             <li>System and Software Design Specification (version {{metadata.referencedDocs.SSDS}})</li>
         </ul>
-        <p>{{{data.sections.sec11.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec11.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -355,7 +371,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec12.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec12.content}}}</td>
+            </tr>
+        </table>
     </div>
 </body>
 </html>

--- a/templates/TIR-infra.html.tmpl
+++ b/templates/TIR-infra.html.tmpl
@@ -255,10 +255,18 @@
         <h2 id="section_5"><span>5</span>Definitions and Abbreviations</h2>
 
         <h3 id="section_5_1"><span>5.1</span>Definitions</h3>
-        <p>{{{data.sections.sec5s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_5_2"><span>5.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec5s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -266,12 +274,20 @@
         <ul>
             <li>Technical Installation Plan(version {{metadata.referencedDocs.TIP}})</li></li>
         </ul>
-        <p>{{{data.sections.sec6.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
         <h2 id="section_7"><span>7</span>Document History</h2>
-        <p>{{{data.sections.sec7.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+            </tr>
+        </table>
     </div>
 </body>
 </html>

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -273,10 +273,18 @@
         <h2 id="section_5"><span>5</span>Definitions and Abbreviations</h2>
 
         <h3 id="section_5_1"><span>5.1</span>Definitions</h3>
-        <p>{{{data.sections.sec5s1.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s1.content}}}</td>
+            </tr>
+        </table>
 
         <h3 id="section_5_2"><span>5.2</span>Abbreviations</h3>
-        <p>{{{data.sections.sec5s2.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec5s2.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -284,7 +292,11 @@
         <ul>
             <li>Technical Installation Plan(version {{metadata.referencedDocs.TIP}})</li></li>
         </ul>
-        <p>{{{data.sections.sec6.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec6.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">
@@ -336,7 +348,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec7.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec7.content}}}</td>
+            </tr>
+        </table>
     </div>
 </body>
 </html>

--- a/templates/TRC.html.tmpl
+++ b/templates/TRC.html.tmpl
@@ -157,7 +157,11 @@
             {{/each}}
         </table>
         {{/if}}
-        <p>{{{data.sections.sec3.content}}}</p>
+        <table>
+            <tr>
+                <td class="content-wrappable">{{{data.sections.sec3.content}}}</td>
+            </tr>
+        </table>
     </div>
 
     <div class="page">


### PR DESCRIPTION
Tables are not rendered correctly when the column content is too long.  This fix forces text to wrap and show correctly