### PR TITLE
Fix IVP and IVR Document History Section is not Correct (v1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+### Fixed
+- IVP and IVR Document History Section is not Correct ([#34](https://github.com/opendevstack/ods-document-generation-templates/pull/34))

--- a/templates/IVP.html.tmpl
+++ b/templates/IVP.html.tmpl
@@ -75,18 +75,17 @@
             </ol>
         </li>
         <li><a href="#section_9">REFERENCE DOCUMENTS</a></li>
-        <li><a href="#section_10">DOCUMENT HISTORY (CONFIGURATION AND INSTALLATION TESTING PLAN)</a></li>
-        <li><a href="#section_11">DOCUMENT HISTORY (CONFIGURATION AND INSTALLATION TESTING REPORT)</a></li>
-        <li><a href="#section_12">TEST CASES TEST GROUP 01 COMPONENTS</a></li>
+        <li><a href="#section_10">DOCUMENT HISTORY</a></li>
+        <li><a href="#section_11">TEST CASES TEST GROUP 01 COMPONENTS</a></li>
         <ol>
-            <li><a href="#section_12_1">SERVER</a></li>
-            <li><a href="#section_12_2">VERIFICATION OF COMPUTER ROOM CONDITIONS</a></li>
-            <li><a href="#section_12_3">REPOSITORY TYPE</a></li>
+            <li><a href="#section_11_1">SERVER</a></li>
+            <li><a href="#section_11_2">VERIFICATION OF COMPUTER ROOM CONDITIONS</a></li>
+            <li><a href="#section_11_3">REPOSITORY TYPE</a></li>
         </ol>
-        <li><a href="#section_13">TEST CASES TEST GROUP 02 SYSTEM LEVEL</a>
+        <li><a href="#section_12">TEST CASES TEST GROUP 02 SYSTEM LEVEL</a>
             <ol>
-                <li><a href="#section_13_1">OPERATIONAL DOCUMENTS ON SYSTEM LEVEL</a></li>
-                <li><a href="#section_13_2">CONFIGURATION DATABASE CMDB</a></li>
+                <li><a href="#section_12_1">OPERATIONAL DOCUMENTS ON SYSTEM LEVEL</a></li>
+                <li><a href="#section_12_2">CONFIGURATION DATABASE CMDB</a></li>
             </ol>
         </li>
     </ol>
@@ -198,7 +197,7 @@ Other test cases:
 	</ul>
 	{{{data.sections.sec9.content}}}
 </div>
-<div class="page"><h2 id="section_10"><span>10</span>DOCUMENT HISTORY (CONFIGURATION AND INSTALLATION TESTING PLAN)</h2>
+<div class="page"><h2 id="section_10"><span>10</span>DOCUMENT HISTORY</h2>
     {{#if data.documentHistory}}
     <table>
         <tr>
@@ -248,23 +247,20 @@ Other test cases:
     {{/if}}
     {{{data.sections.sec10.content}}}
 </div>
-<div class="page"><h2 id="section_11"><span>11</span>DOCUMENT HISTORY (CONFIGURATION AND INSTALLATION TESTING REPORT)</h2>
-	N/A - As the report is based on the most up to date version of the plan, there is no need for a separate History
-</div>
 
-<div class="page"><h2 id="section_12"><span>12</span>TEST CASES TEST GROUP 01 COMPONENTS</h2>
+<div class="page"><h2 id="section_11"><span>11</span>TEST CASES TEST GROUP 01 COMPONENTS</h2>
 	<!-- render test case fields from zephyr with IVP -->
-    <h3 id="section_12_1"><span>12.1</span>SERVER</h3>
+    <h3 id="section_11_1"><span>11.1</span>SERVER</h3>
     Containers are volatile, that means the underlying platform decides depending on resource usage and consumption - where (on which server(s)) and how a container is run.<br>
     Only the TIR (that is created as part of the installation) contains the information where a pod was located at that point in time - hence we leave this information out of the CIT, which is generated at a later point in time.<br>
 
-    <h3 id="section_12_2"><span>12.2</span>VERIFICATION OF COMPUTER ROOM CONDITIONS</h3>
+    <h3 id="section_11_2"><span>11.2</span>VERIFICATION OF COMPUTER ROOM CONDITIONS</h3>
     Containers are volatile, that means the underlying platform decides depending on resource usage and consumption - where (on which server(s)) and how a container is run.<br>
     Only the TIR (that is created as part of the installation) contains the information where a pod was located at that point in time - hence we leave this information out of the CIT, which is generated at a later point in time.<br>
 
-    <h3 id="section_12_3"><span>12.3</span>REPOSITORY TYPE</h3>
+    <h3 id="section_11_3"><span>11.3</span>REPOSITORY TYPE</h3>
 
-    <h4 id="section_12_3_1"><span>12.3.1 </span>ODS</h4>
+    <h4 id="section_11_3_1"><span>11.3.1 </span>ODS</h4>
 	{{#if data.testsOdsCode}}
     <table class="no-page-break">
         <tr>
@@ -294,7 +290,7 @@ Other test cases:
 		<p><em>N/A</em></p>
 	{{/if}}
 
-    <h4 id="section_12_3_2"><span>12.3.2 </span>ODS-SERVICE</h4>
+    <h4 id="section_11_3_2"><span>11.3.2 </span>ODS-SERVICE</h4>
 	{{#if data.testsOdsService}}
     <table class="no-page-break">
         <tr>
@@ -323,12 +319,12 @@ Other test cases:
 	<!-- report: results / executions -->
 </div>
 
-<div class="page"><h2 id="section_13"><span>13</span>TEST CASES TEST GROUP 02 SYSTEM LEVEL</h2>
+<div class="page"><h2 id="section_12"><span>12</span>TEST CASES TEST GROUP 02 SYSTEM LEVEL</h2>
 	<ul>
 		<li>
-			<div class="page"><h3 id="section_13_1"><span>13.1</span>OPERATIONAL DOCUMENTS ON SYSTEM LEVEL</h3>
+			<div class="page"><h3 id="section_12_1"><span>12.1</span>OPERATIONAL DOCUMENTS ON SYSTEM LEVEL</h3>
 				<!-- backup and monitoring plan for qualified infrastructure -->
-                {{{data.sections.sec13s1.content}}}
+                {{{data.sections.sec12s1.content}}}
                 <!-- <p><b>System level monitoring:</b></p>
                 <table class="System level monitoring">
                     <tr>
@@ -465,11 +461,11 @@ Other test cases:
 			</div>
 		</li>
 		<li>
-			<div class="page"><h3 id="section_13_2"><span>13.2</span>CONFIGURATION DATABASE CMDB</h3>
+			<div class="page"><h3 id="section_12_2"><span>12.2</span>CONFIGURATION DATABASE CMDB</h3>
 				Configuration Data of Config Item '{{metadata.name}}' is correct and verified
 				<table style="border: 0px; padding: 0px; margin: 0px">
 					<tr>
-						<td class="content-wrappable" style="border: 0px; padding: 0px; margin: 0px;">{{{data.sections.sec13s2.content}}}</td>
+						<td class="content-wrappable" style="border: 0px; padding: 0px; margin: 0px;">{{{data.sections.sec12s2.content}}}</td>
 					</tr>
 				</table>
 			</div>

--- a/templates/IVR.html.tmpl
+++ b/templates/IVR.html.tmpl
@@ -79,23 +79,22 @@
             </ol>
         </li>
         <li><a href="#section_9">REFERENCE DOCUMENTS</a></li>
-        <li><a href="#section_10">DOCUMENT HISTORY (CONFIGURATION AND INSTALLATION TESTING PLAN)</a></li>
-        <li><a href="#section_11">DOCUMENT HISTORY (CONFIGURATION AND INSTALLATION TESTING REPORT)</a></li>
-        <li><a href="#section_12">TEST CASES TEST GROUP 01 COMPONENTS</a></li>
+        <li><a href="#section_10">DOCUMENT HISTORY</a></li>
+        <li><a href="#section_11">TEST CASES TEST GROUP 01 COMPONENTS</a></li>
         <ol>
-            <li><a href="#section_12_1">SERVER</a></li>
-            <li><a href="#section_12_2">VERIFICATION OF COMPUTER ROOM CONDITIONS</a></li>
-            <li><a href="#section_12_3">REPOSITORY TYPE</a></li>
+            <li><a href="#section_11_1">SERVER</a></li>
+            <li><a href="#section_11_2">VERIFICATION OF COMPUTER ROOM CONDITIONS</a></li>
+            <li><a href="#section_11_3">REPOSITORY TYPE</a></li>
         </ol>
-        <li><a href="#section_13">TEST CASES TEST GROUP 02 SYSTEM LEVEL</a>
+        <li><a href="#section_12">TEST CASES TEST GROUP 02 SYSTEM LEVEL</a>
             <ol>
-                <li><a href="#section_13_1">OPERATIONAL DOCUMENTS ON SYSTEM LEVEL</a></li>
-                <li><a href="#section_13_2">CONFIGURATION DATABASE CMDB</a></li>
+                <li><a href="#section_12_1">OPERATIONAL DOCUMENTS ON SYSTEM LEVEL</a></li>
+                <li><a href="#section_12_2">CONFIGURATION DATABASE CMDB</a></li>
             </ol>
         </li>
-		<li><a href="#section_14">Attachments</a>
+		<li><a href="#section_13">Attachments</a>
 			<ol>
-				<li><a href="#section_14_1">xUnit XML Documents</a></li>
+				<li><a href="#section_13_1">xUnit XML Documents</a></li>
 			</ol>
 		</li>
     </ol>
@@ -254,23 +253,20 @@ Other test cases:
     {{/if}}
     {{{data.sections.sec10.content}}}
 </div>
-<div class="page"><h2 id="section_11"><span>11</span>DOCUMENT HISTORY (CONFIGURATION AND INSTALLATION TESTING REPORT)</h2>
-	N/A - As the report is based on the most up to date version of the plan, there is no need for a separate History
-</div>
 
-<div class="page"><h2 id="section_12"><span>12</span>TEST CASES TEST GROUP 01 COMPONENTS</h2>
+<div class="page"><h2 id="section_11"><span>11</span>TEST CASES TEST GROUP 01 COMPONENTS</h2>
 	<!-- render test case fields from zephyr with IVP -->
-    <h3 id="section_12_1"><span>12.1</span>SERVER</h3>
+    <h3 id="section_11_1"><span>11.1</span>SERVER</h3>
     Containers are volatile, that means the underlying platform decides depending on resource usage and consumption - where (on which server(s)) and how a container is run.<br>
     Only the TIR (that is created as part of the installation) contains the information where a pod was located at that point in time - hence we leave this information out of the CIT, which is generated at a later point in time.<br>
 
-    <h3 id="section_12_2"><span>12.2</span>VERIFICATION OF COMPUTER ROOM CONDITIONS</h3>
+    <h3 id="section_11_2"><span>11.2</span>VERIFICATION OF COMPUTER ROOM CONDITIONS</h3>
     Containers are volatile, that means the underlying platform decides depending on resource usage and consumption - where (on which server(s)) and how a container is run.<br>
     Only the TIR (that is created as part of the installation) contains the information where a pod was located at that point in time - hence we leave this information out of the CIT, which is generated at a later point in time.<br>
 
-    <h3 id="section_12_3"><span>12.3</span>REPOSITORY TYPE</h3>
+    <h3 id="section_11_3"><span>11.3</span>REPOSITORY TYPE</h3>
 
-    <h4 id="section_12_3_1"><span>12.3.1 </span>ODS</h4>
+    <h4 id="section_11_3_1"><span>11.3.1 </span>ODS</h4>
 	{{#if data.testsOdsCode}}
     <table class="no-page-break">
         <tr>
@@ -300,7 +296,7 @@ Other test cases:
 		<p><em>N/A</em></p>
 	{{/if}}
 
-    <h4 id="section_12_3_2"><span>12.3.2 </span>ODS-SERVICE</h4>
+    <h4 id="section_11_3_2"><span>11.3.2 </span>ODS-SERVICE</h4>
 	{{#if data.testsOdsService}}
     <table class="no-page-break">
         <tr>
@@ -329,12 +325,12 @@ Other test cases:
 	<!-- report: results / executions -->
 </div>
 
-<div class="page"><h2 id="section_13"><span>13</span>TEST CASES TEST GROUP 02 SYSTEM LEVEL</h2>
+<div class="page"><h2 id="section_12"><span>12</span>TEST CASES TEST GROUP 02 SYSTEM LEVEL</h2>
 	<ul>
 		<li>
-			<div class="page"><h3 id="section_13_1"><span>13.1</span>OPERATIONAL DOCUMENTS ON SYSTEM LEVEL</h3>
+			<div class="page"><h3 id="section_12_1"><span>12.1</span>OPERATIONAL DOCUMENTS ON SYSTEM LEVEL</h3>
 				<!-- backup and monitoring plan for qualified infrastructure -->
-                {{{data.sections.sec13s1.content}}}
+                {{{data.sections.sec12s1.content}}}
                                 <!-- <p><b>System level monitoring:</b></p>
                 <table class="System level monitoring">
                     <tr>
@@ -471,11 +467,11 @@ Other test cases:
 			</div>
 		</li>
 		<li>
-			<div class="page"><h3 id="section_13_2"><span>13.2</span>CONFIGURATION DATABASE CMDB</h3>
+			<div class="page"><h3 id="section_12_2"><span>12.2</span>CONFIGURATION DATABASE CMDB</h3>
 				Configuration Data of Config Item '{{metadata.name}}' is correct and verified
 				<table style="border: 0px; padding: 0px; margin: 0px">
 					<tr>
-						<td class="content-wrappable" style="border: 0px; padding: 0px; margin: 0px;">{{{data.sections.sec13s2.content}}}</td>
+						<td class="content-wrappable" style="border: 0px; padding: 0px; margin: 0px;">{{{data.sections.sec12s2.content}}}</td>
 					</tr>
 				</table>
 			</div>
@@ -484,8 +480,8 @@ Other test cases:
 </div>
 
 <div class="page">
-	<h2 id="section_14"><span>14</span>Attachments</h2>
-	<h3 id="section_14_1"><span>14.1</span>xUnit XML Documents</h3>
+	<h2 id="section_13"><span>13</span>Attachments</h2>
+	<h3 id="section_13_1"><span>13.1</span>xUnit XML Documents</h3>
 	<p>The information included in this test results provides the xUnit XML results of the execution of the system {{metadata.name}} created by Jenkins Job Name {{metadata.jenkins.jobName}} and Jenkins Build Number {{metadata.jenkins.buildNumber}}.</p>
 	{{#if data.testFiles}}
 		{{#each data.testFiles}}


### PR DESCRIPTION
For IVP and IVR, rename section 10 (Document History), remove section 11 and renumber subsequent sections.