### PR TITLE
Fixes regarding TIP, TIR and document histories

### DIFF
--- a/templates/CFTP-1.html.tmpl
+++ b/templates/CFTP-1.html.tmpl
@@ -397,7 +397,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -405,7 +405,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -413,7 +413,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/CFTP-3.html.tmpl
+++ b/templates/CFTP-3.html.tmpl
@@ -402,7 +402,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -410,7 +410,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -418,7 +418,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/CFTP-4.html.tmpl
+++ b/templates/CFTP-4.html.tmpl
@@ -406,7 +406,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -414,7 +414,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -422,7 +422,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/CFTP-5.html.tmpl
+++ b/templates/CFTP-5.html.tmpl
@@ -405,7 +405,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -413,7 +413,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -421,7 +421,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/CFTR-1.html.tmpl
+++ b/templates/CFTR-1.html.tmpl
@@ -268,7 +268,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -276,7 +276,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -284,7 +284,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/CFTR-3.html.tmpl
+++ b/templates/CFTR-3.html.tmpl
@@ -270,7 +270,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -278,7 +278,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -286,7 +286,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/CFTR-4.html.tmpl
+++ b/templates/CFTR-4.html.tmpl
@@ -297,7 +297,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -305,7 +305,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -313,7 +313,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/CFTR-5.html.tmpl
+++ b/templates/CFTR-5.html.tmpl
@@ -297,7 +297,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -305,7 +305,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -313,7 +313,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/CSD-1.html.tmpl
+++ b/templates/CSD-1.html.tmpl
@@ -158,7 +158,7 @@
                     {{/each}}
                 </table>
                 {{/if}}
-           
+
                 {{#each data.requirements.functionalrequirements.epics}}
                     <h5 id="section_3_2_1_{{epicIndex}}"><span>3.2.1.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
                     <span>{{{epicDescription}}}</span>
@@ -223,7 +223,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.datarequirements.epics}}
                     <h5 id="section_3_2_2_{{epicIndex}}"><span>3.2.2.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
@@ -257,7 +257,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}} 
+            {{/if}}
 
 
             <h4 id="section_3_2_3"><span>3.2.3</span> Technical Requirements</h4>
@@ -302,7 +302,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.securityrequirements.epics}}
                     <h5 id="section_3_3_3_{{epicIndex}}"><span>3.3.3.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
@@ -336,7 +336,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
             <h4 id="section_3_3_4"><span>3.3.4</span> Regulatory Requirements</h4>
@@ -374,7 +374,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.roles.epics}}
                     <h4 id="section_3_5_{{epicIndex}}"><span>3.5.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -404,11 +404,11 @@
                             <td class="lean">N/A</td>
                         </tr>
                         {{/each}}
-                    </table>                    
+                    </table>
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
         <h3 id="section_3_6"><span>3.6</span>Interfaces</h3>
             {{#if data.requirements.interfacerequirements}}
@@ -439,7 +439,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.interfacerequirements.epics}}
                 <h4 id="section_3_6_{{epicIndex}}"><span>3.6.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -473,7 +473,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
         <h3 id="section_3_7"><span>3.7</span>Operational Environment</h3>
@@ -505,7 +505,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.environmentrequirements.epics}}
                     <h4 id="section_3_7_{{epicIndex}}"><span>3.7.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -539,7 +539,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
 
@@ -572,7 +572,7 @@
                     </tr>
                     {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.uncategorized.epics}}
                 <h4 id="section_3_8_{{epicIndex}}"><span>3.8.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -606,7 +606,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
     </div>
@@ -643,7 +643,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.compatibility.epics}}
                 <h4 id="section_4_1_{{epicIndex}}"><span>4.1.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -677,7 +677,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}} 
+            {{/if}}
 
 
         <h3 id="section_4_2"><span>4.2</span>Procedural Constraints</h3>
@@ -709,7 +709,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.proceduralconstraints.epics}}
                 <h4 id="section_4_2_{{epicIndex}}"><span>4.2.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -743,7 +743,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
     </div>
 
@@ -796,7 +796,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -804,7 +804,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -812,7 +812,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/CSD-3.html.tmpl
+++ b/templates/CSD-3.html.tmpl
@@ -238,7 +238,7 @@
                     </tr>
                     {{/each}}
                 </table>
-            {{/if}}      
+            {{/if}}
 
             {{#each data.requirements.performancerequirements.epics}}
                 <h5 id="section_3_3_1_{{epicIndex}}"><span>3.3.1.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
@@ -304,7 +304,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.availabilityrequirements.epics}}
                     <h5 id="section_3_3_2_{{epicIndex}}"><span>3.3.2.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
@@ -338,7 +338,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}} 
+            {{/if}}
 
             <h4 id="section_3_3_3"><span>3.3.3</span> Security Requirements</h4>
             <p>N/A</p>
@@ -382,7 +382,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.interfacerequirements.epics}}
                     <h4 id="section_3_6_{{epicIndex}}"><span>3.6.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -412,11 +412,11 @@
                             <td class="lean">N/A</td>
                         </tr>
                         {{/each}}
-                    </table>                
+                    </table>
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
 
@@ -449,7 +449,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.environmentrequirements.epics}}
                     <h4 id="section_3_7_{{epicIndex}}"><span>3.7.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -483,7 +483,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
 
@@ -516,7 +516,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.uncategorized.epics}}
                     <h4 id="section_3_8_{{epicIndex}}"><span>3.8.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -550,7 +550,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
     </div>
 
@@ -586,7 +586,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.compatibility.epics}}
                     <h4 id="section_4_1_{{epicIndex}}"><span>4.1.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -620,7 +620,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
         <h3 id="section_4_2"><span>4.2</span>Procedural Constraints</h3>
@@ -652,7 +652,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.proceduralconstraints.epics}}
                     <h4 id="section_4_2_{{epicIndex}}"><span>4.2.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -686,7 +686,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
     </div>
 
@@ -739,7 +739,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -747,7 +747,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -755,7 +755,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/CSD-4.html.tmpl
+++ b/templates/CSD-4.html.tmpl
@@ -290,7 +290,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
                 {{#each data.requirements.datarequirements.epics}}
                     <h5 id="section_3_2_2_{{epicIndex}}"><span>3.2.2.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
                     <span>{{{epicDescription}}}</span>
@@ -323,7 +323,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}     
+            {{/if}}
 
 
             <h4 id="section_3_2_3"><span>3.2.3</span> Technical Requirements</h4>
@@ -362,7 +362,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.performancerequirements.epics}}
                     <h5 id="section_3_3_1_{{epicIndex}}"><span>3.3.1.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
@@ -396,7 +396,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
             <h4 id="section_3_3_2"><span>3.3.2</span> Availability Requirements</h4>
             {{#if data.requirements.availabilityrequirements}}
@@ -460,7 +460,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
             <h4 id="section_3_3_3"><span>3.3.3</span> Security Requirements</h4>
             {{#if data.requirements.securityrequirements}}
@@ -524,7 +524,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
 
@@ -563,7 +563,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.roles.epics}}
                     <h4 id="section_3_5_{{epicIndex}}"><span>3.5.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -593,12 +593,12 @@
                             <td class="lean">{{applicability}}</td>
                         </tr>
                     {{/each}}
-                </table>                    
+                </table>
             {{/each}}
         {{else}}
             <p><em>N/A</em></p>
         {{/if}}
-            
+
         <h3 id="section_3_6"><span>3.6</span>Interfaces</h3>
             {{#if data.requirements.interfacerequirements}}
                 {{#if data.requirements.interfacerequirements.noepics}}
@@ -628,7 +628,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.interfacerequirements.epics}}
                     <h4 id="section_3_6_{{epicIndex}}"><span>3.6.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -658,11 +658,11 @@
                             <td class="lean">{{applicability}}</td>
                         </tr>
                         {{/each}}
-                    </table>                    
+                    </table>
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
         <h3 id="section_3_7"><span>3.7</span>Operational Environment</h3>
             {{#if data.requirements.environmentrequirements}}
@@ -725,7 +725,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 		<h3 id="section_3_8"><span>3.8</span> Uncategorized Requirements</h3>
             {{#if data.requirements.uncategorized}}
@@ -756,7 +756,7 @@
                     </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.uncategorized.epics}}
                     <h4 id="section_3_8_{{epicIndex}}"><span>3.8.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -790,7 +790,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
     </div>
@@ -827,7 +827,7 @@
                 </tr>
                 {{/each}}
              </table>
-            {{/if}}      
+            {{/if}}
 
             {{#each data.requirements.compatibility.epics}}
                 <h4 id="section_4_1_{{epicIndex}}"><span>4.1.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -861,7 +861,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
         <h3 id="section_4_2"><span>4.2</span>Procedural Constraints</h3>
@@ -893,7 +893,7 @@
                         </tr>
                     {{/each}}
                 </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.proceduralconstraints.epics}}
                     <h4 id="section_4_2_{{epicIndex}}"><span>4.2.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -927,7 +927,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
     </div>
@@ -981,7 +981,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -989,7 +989,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -997,7 +997,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/CSD-5.html.tmpl
+++ b/templates/CSD-5.html.tmpl
@@ -226,7 +226,7 @@
                         {{/each}}
                     </table>
                 {{/if}}
-           
+
                 {{#each data.requirements.functionalrequirements.epics}}
                     <h5 id="section_3_2_1_{{epicIndex}}"><span>3.2.1.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
                     <span>{{{epicDescription}}}</span>
@@ -292,7 +292,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.datarequirements.epics}}
                     <h5 id="section_3_2_2_{{epicIndex}}"><span>3.2.2.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
@@ -326,7 +326,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}                
+            {{/if}}
 
 
 
@@ -362,7 +362,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.technicalrequirements.epics}}
                     <h5 id="section_3_2_3_{{epicIndex}}"><span>3.2.3.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
@@ -396,7 +396,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
             <h4 id="section_3_2_4"><span>3.2.4</span> Maintenance Requirements</h4>
             {{#if data.requirements.maintenancerequirements}}
@@ -427,7 +427,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.maintenancerequirements.epics}}
                     <h5 id="section_3_2_4_{{epicIndex}}"><span>3.2.4.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
@@ -461,7 +461,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
         <h3 id="section_3_3"><span>3.3</span>Non-Operational Requirements</h3>
@@ -494,7 +494,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.performancerequirements.epics}}
                     <h5 id="section_3_3_1_{{epicIndex}}"><span>3.3.1.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
@@ -528,7 +528,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
 
@@ -561,7 +561,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.availabilityrequirements.epics}}
                     <h5 id="section_3_3_2_{{epicIndex}}"><span>3.3.2.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
@@ -595,7 +595,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
             <h4 id="section_3_3_3"><span>3.3.3</span> Security Requirements</h4>
@@ -627,7 +627,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.securityrequirements.epics}}
                     <h5 id="section_3_3_3_{{epicIndex}}"><span>3.3.3.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
@@ -661,7 +661,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
             <h4 id="section_3_3_4"><span>3.3.4</span> Regulatory Requirements</h4>
@@ -693,7 +693,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.regulatoryrequirements.epics}}
                     <h5 id="section_3_3_4_{{epicIndex}}"><span>3.3.4.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h5>
@@ -727,7 +727,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
         <h3 id="section_3_4"><span>3.4</span>Overarching Requirements</h3>
@@ -759,7 +759,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.overarchingrequirements.epics}}
                     <h4 id="section_3_4_{{epicIndex}}"><span>3.4.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -793,7 +793,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
         <h3 id="section_3_5"><span>3.5</span>Roles</h3>
@@ -825,7 +825,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.roles.epics}}
                     <h4 id="section_3_5_{{epicIndex}}"><span>3.5.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -859,7 +859,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
         <h3 id="section_3_6"><span>3.6</span>Interfaces</h3>
             {{#if data.requirements.interfacerequirements}}
@@ -890,7 +890,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.interfacerequirements.epics}}
                     <h4 id="section_3_6_{{epicIndex}}"><span>3.6.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -924,7 +924,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
         <h3 id="section_3_7"><span>3.7</span>Operational Environment</h3>
@@ -956,7 +956,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.environmentrequirements.epics}}
                     <h4 id="section_3_7_{{epicIndex}}"><span>3.7.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -990,7 +990,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
 
 		<h3 id="section_3_8"><span>3.8</span> Uncategorized Requirements</h3>
@@ -1022,7 +1022,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.uncategorized.epics}}
                     <h4 id="section_3_8_{{epicIndex}}"><span>3.8.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -1056,7 +1056,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
     </div>
 
     <div class="page">
@@ -1091,7 +1091,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.compatibility.epics}}
                     <h4 id="section_4_1_{{epicIndex}}"><span>4.1.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -1125,7 +1125,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
 
         <h3 id="section_4_2"><span>4.2</span>Procedural Constraints</h3>
             {{#if data.requirements.proceduralconstraints}}
@@ -1156,7 +1156,7 @@
                         </tr>
                         {{/each}}
                     </table>
-                {{/if}}      
+                {{/if}}
 
                 {{#each data.requirements.proceduralconstraints.epics}}
                     <h4 id="section_4_2_{{epicIndex}}"><span>4.2.{{epicIndex}}</span>{{key}}: {{epicTitle}}</h4>
@@ -1190,7 +1190,7 @@
                 {{/each}}
 			{{else}}
              <p><em>N/A</em></p>
-            {{/if}}  
+            {{/if}}
     </div>
 
     <div class="page">
@@ -1242,7 +1242,7 @@
                 The following {{type}} were added:
                 <ul>
                     {{#each added}}
-                    <li>{{key}}</li>
+                    <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                     {{/each}}
                 </ul>
                 {{/if}}
@@ -1250,7 +1250,7 @@
                 The following {{type}} were removed:
                 <ul>
                     {{#each discontinued}}
-                    <li>{{key}}</li>
+                    <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                     {{/each}}
                 </ul>
                 {{/if}}
@@ -1258,7 +1258,7 @@
                 The following {{type}} were changed:
                 <ul>
                     {{#each changed}}
-                    <li>{{key}} was previously {{predecessors}}</li>
+                    <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                     {{/each}}
                 </ul>
                 {{/if}}

--- a/templates/DTP.html.tmpl
+++ b/templates/DTP.html.tmpl
@@ -254,7 +254,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -262,7 +262,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -270,7 +270,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/DTR.html.tmpl
+++ b/templates/DTR.html.tmpl
@@ -223,7 +223,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -231,7 +231,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -239,7 +239,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/IVP.html.tmpl
+++ b/templates/IVP.html.tmpl
@@ -234,7 +234,7 @@ Other test cases:
                 The following {{type}} were added:
                 <ul>
                     {{#each added}}
-                    <li>{{key}}</li>
+                    <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                     {{/each}}
                 </ul>
                 {{/if}}
@@ -242,7 +242,7 @@ Other test cases:
                 The following {{type}} were removed:
                 <ul>
                     {{#each discontinued}}
-                    <li>{{key}}</li>
+                    <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                     {{/each}}
                 </ul>
                 {{/if}}
@@ -250,7 +250,7 @@ Other test cases:
                 The following {{type}} were changed:
                 <ul>
                     {{#each changed}}
-                    <li>{{key}} was previously {{predecessors}}</li>
+                    <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                     {{/each}}
                 </ul>
                 {{/if}}

--- a/templates/IVR.html.tmpl
+++ b/templates/IVR.html.tmpl
@@ -240,7 +240,7 @@ Other test cases:
                 The following {{type}} were added:
                 <ul>
                     {{#each added}}
-                    <li>{{key}}</li>
+                    <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                     {{/each}}
                 </ul>
                 {{/if}}
@@ -248,7 +248,7 @@ Other test cases:
                 The following {{type}} were removed:
                 <ul>
                     {{#each discontinued}}
-                    <li>{{key}}</li>
+                    <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                     {{/each}}
                 </ul>
                 {{/if}}
@@ -256,7 +256,7 @@ Other test cases:
                 The following {{type}} were changed:
                 <ul>
                     {{#each changed}}
-                    <li>{{key}} was previously {{predecessors}}</li>
+                    <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                     {{/each}}
                 </ul>
                 {{/if}}

--- a/templates/RA.html.tmpl
+++ b/templates/RA.html.tmpl
@@ -490,7 +490,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -498,7 +498,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -506,7 +506,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/SSDS-1.html.tmpl
+++ b/templates/SSDS-1.html.tmpl
@@ -420,7 +420,7 @@
                         The following {{type}} were added:
                         <ul>
                             {{#each added}}
-                            <li>{{key}}</li>
+                            <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                             {{/each}}
                         </ul>
                         {{/if}}
@@ -428,7 +428,7 @@
                         The following {{type}} were removed:
                         <ul>
                             {{#each discontinued}}
-                            <li>{{key}}</li>
+                            <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                             {{/each}}
                         </ul>
                         {{/if}}
@@ -436,7 +436,7 @@
                         The following {{type}} were changed:
                         <ul>
                             {{#each changed}}
-                            <li>{{key}} was previously {{predecessors}}</li>
+                            <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                             {{/each}}
                         </ul>
                         {{/if}}

--- a/templates/SSDS-3.html.tmpl
+++ b/templates/SSDS-3.html.tmpl
@@ -417,7 +417,7 @@
                         The following {{type}} were added:
                         <ul>
                             {{#each added}}
-                            <li>{{key}}</li>
+                            <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                             {{/each}}
                         </ul>
                         {{/if}}
@@ -425,7 +425,7 @@
                         The following {{type}} were removed:
                         <ul>
                             {{#each discontinued}}
-                            <li>{{key}}</li>
+                            <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                             {{/each}}
                         </ul>
                         {{/if}}
@@ -433,7 +433,7 @@
                         The following {{type}} were changed:
                         <ul>
                             {{#each changed}}
-                            <li>{{key}} was previously {{predecessors}}</li>
+                            <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                             {{/each}}
                         </ul>
                         {{/if}}

--- a/templates/SSDS-4.html.tmpl
+++ b/templates/SSDS-4.html.tmpl
@@ -415,7 +415,7 @@
                         The following {{type}} were added:
                         <ul>
                             {{#each added}}
-                            <li>{{key}}</li>
+                            <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                             {{/each}}
                         </ul>
                         {{/if}}
@@ -423,7 +423,7 @@
                         The following {{type}} were removed:
                         <ul>
                             {{#each discontinued}}
-                            <li>{{key}}</li>
+                            <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                             {{/each}}
                         </ul>
                         {{/if}}
@@ -431,7 +431,7 @@
                         The following {{type}} were changed:
                         <ul>
                             {{#each changed}}
-                            <li>{{key}} was previously {{predecessors}}</li>
+                            <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                             {{/each}}
                         </ul>
                         {{/if}}

--- a/templates/SSDS-5.html.tmpl
+++ b/templates/SSDS-5.html.tmpl
@@ -518,7 +518,7 @@
                         The following {{type}} were added:
                         <ul>
                             {{#each added}}
-                            <li>{{key}}</li>
+                            <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                             {{/each}}
                         </ul>
                         {{/if}}
@@ -526,7 +526,7 @@
                         The following {{type}} were removed:
                         <ul>
                             {{#each discontinued}}
-                            <li>{{key}}</li>
+                            <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                             {{/each}}
                         </ul>
                         {{/if}}
@@ -534,7 +534,7 @@
                         The following {{type}} were changed:
                         <ul>
                             {{#each changed}}
-                            <li>{{key}} was previously {{predecessors}}</li>
+                            <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                             {{/each}}
                         </ul>
                         {{/if}}

--- a/templates/TCP.html.tmpl
+++ b/templates/TCP.html.tmpl
@@ -104,7 +104,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -112,7 +112,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -120,7 +120,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/TCR.html.tmpl
+++ b/templates/TCR.html.tmpl
@@ -113,7 +113,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -121,7 +121,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -129,7 +129,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/TIP.html.tmpl
+++ b/templates/TIP.html.tmpl
@@ -344,7 +344,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -352,7 +352,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -360,7 +360,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/TIP.html.tmpl
+++ b/templates/TIP.html.tmpl
@@ -99,7 +99,7 @@
 
     <div class="page">
         <h2 id="section_1"><span>1</span>Introduction</h2>
-        <p>This document describes the installation of the software-defined component <em>{{metadata.buildParameter.configItem}}</em>. The installation is based on the documented installation process for applications/components running on <em>BI-IT-DEVSTACK</em>.</p>
+        <p>This document describes the installation of the software-defined component{{#each data.repositories}}{{#unless @first}}{{#if @last}}s{{/if}}{{/unless}}{{/each}} <em>{{#each data.repositories}}{{#unless @first}}{{#if @last}} and{{else}},{{/if}} {{/unless}}{{id}}{{/each}}</em>. The installation is based on the documented installation process for applications/components running on <em>BI-IT-DEVSTACK</em>.</p>
 
         <table>
         <tr>

--- a/templates/TIR-infra.html.tmpl
+++ b/templates/TIR-infra.html.tmpl
@@ -91,7 +91,7 @@
     <div class="page">
         <h2 id="section_1"><span>1</span>Introduction</h2>
 
-        <p>This document describes the installation of the component <em>{{metadata.buildParameter.configItem}}</em>. The installation is based on the corresponding Technical Installation Plan (<em>TIP</em>) of Config Item: {{metadata.buildParameter.configItem}}.</p>
+        <p>This document describes the installation of the component <em>{{data.repo.id}}</em>. The installation is based on the corresponding Technical Installation Plan (<em>TIP</em>) of Config Item: {{metadata.buildParameter.configItem}}.</p>
 
         <p>The plan outlines additional chapters, namely <em>Installation Prerequisites (3)</em> and <em>Environmental Conditions (4)</em>.</p>
 
@@ -170,30 +170,30 @@
             </tr>
         </table>
 
-        
+
         <h3 id="subcomponents"><span>2.2</span>Components</h3>
-        
+
         {{#data.repo}}
         <p>The following components have been successfully installed:<b>{{id}}</b></p>
         {{/data.repo}}
 
         {{#data.repo.data}}
-        
+
         <h4>Target Deployment Environment</h4>
         <p>The following identifier gives information about the target deployment environment, eg. AWS Account, Azure Subscription:</p>
         <p>{{logs.target.content}}.</p>
         <br>
-        
+
         <h4>Created Resources</h4>
         <p>The following resources have been created to reach the desired state within the target deployment environment:</p>
-       
+
         {{#if logs.created.content}}
             <p><pre>{{logs.created.content}}</pre></p>
         {{else}}
             <p><b>No resources have been created. The target is already in the desired state.</b></p>
         {{/if}}
-        <br>  
-    
+        <br>
+
         {{/data.repo.data}}
 
     </div>
@@ -215,7 +215,7 @@
         {{#each data.repo.data.tests.installation.testResults.testsuites}}
         <h4>Test suite "{{name}}"</h4>
         <p>Test suite "{{name}}" ran {{tests}} tests of which {{failures}} tests have failed.</p>
-        
+
         {{#if testcases}}
         <table>
             <tr>
@@ -229,7 +229,7 @@
             </tr>
             {{/each}}
         </table>
-        {{else}}           
+        {{else}}
         <table>
         <tr>
             <th class="lean">Test Description</th>

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -321,7 +321,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -329,7 +329,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -337,7 +337,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -91,7 +91,7 @@
     <div class="page">
         <h2 id="section_1"><span>1</span>Introduction</h2>
 
-        <p>This document describes the installation of the software-defined component <em>{{metadata.buildParameter.configItem}}</em>. The installation is based on the corresponding Technical Installation Plan (<em>TIP</em>) of Config Item: {{metadata.buildParameter.configItem}}.</p>
+        <p>This document describes the installation of the software-defined component <em>{{data.repo.id}}</em>. The installation is based on the corresponding Technical Installation Plan (<em>TIP</em>) of Config Item: {{metadata.buildParameter.configItem}}.</p>
 
         <p>The plan outlines additional chapters, namely <em>Installation Prerequisites (3)</em> and <em>Environmental Conditions (4)</em>.</p>
 

--- a/templates/TRC.html.tmpl
+++ b/templates/TRC.html.tmpl
@@ -130,7 +130,7 @@
                     The following {{type}} were added:
                     <ul>
                         {{#each added}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -138,7 +138,7 @@
                     The following {{type}} were removed:
                     <ul>
                         {{#each discontinued}}
-                        <li>{{key}}</li>
+                        <li>{{key}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -146,7 +146,7 @@
                     The following {{type}} were changed:
                     <ul>
                         {{#each changed}}
-                        <li>{{key}} was previously {{predecessors}}</li>
+                        <li>{{key}} was previously {{predecessors}}{{#if details}}: {{details}}{{/if}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}


### PR DESCRIPTION
In the TIR introduction, show the component name instead of the system name (#29)
In the TIP introduction, show the component list instead of the system name (#30)
Show optional details in the document-history entries (#28)