### PR TITLE
Fix indices in component-level documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Modified SSDS document to use Pull Request info not SonarQube ([#614](https://github.com/opendevstack/ods-jenkins-shared-library/pull/614))
 - Add missing table in RA document ([#50](https://github.com/opendevstack/ods-document-generation-templates/pull/50))
 - Add missing column in section 4 of TRC document ([#51](https://github.com/opendevstack/ods-document-generation-templates/pull/51))
+- TIR and DTR documents are not properly indexed ([#47](https://github.com/opendevstack/ods-document-generation-templates/pull/47))
 
 ### Fixed - 2021-04-22
 - Fix the document history section for IVR still shows the wrong title ([#44](https://github.com/opendevstack/ods-document-generation-templates/pull/44))

--- a/templates/TIR-infra.html.tmpl
+++ b/templates/TIR-infra.html.tmpl
@@ -148,7 +148,7 @@
             </tr>
         </table>
 
-        <h3 id="section_3"><span>2.1</span>Jenkins</h3>
+        <h3 id="section_2_1"><span>2.1</span>Jenkins</h3>
         <p>Jenkins Job has been successfully executed:</p>
 
         <table>
@@ -171,7 +171,7 @@
         </table>
 
 
-        <h3 id="subcomponents"><span>2.2</span>Components</h3>
+        <h3 id="section_2_2"><span>2.2</span>Components</h3>
 
         {{#data.repo}}
         <p>The following components have been successfully installed:<b>{{id}}</b></p>
@@ -199,7 +199,7 @@
     </div>
 
     <div class="page">
-        <h2 id="diagnostics-and-testing"><span>3</span>Diagnostics and Testing</h2>
+        <h2 id="section_3"><span>3</span>Diagnostics and Testing</h2>
         <p>Diagnostic steps have been successfully applied to the requested component.</p>
 
         <h3>Diagnostic Status</h3>

--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -144,7 +144,7 @@
             </tr>
         </table>
 
-        <h3 id="section_3"><span>2.1</span>Jenkins</h3>
+        <h3 id="section_2_1"><span>2.1</span>Jenkins</h3>
         <p>Jenkins Job has been successfully executed:</p>
 
         <table>
@@ -166,7 +166,7 @@
             </tr>
         </table>
 
-        <h3 id="subcomponents"><span>2.2</span>Components</h3>
+        <h3 id="section_2_2"><span>2.2</span>Components</h3>
         <p><b>Note:</b> {{deployNote}}</p>
 
         {{#data.repo}}
@@ -223,7 +223,7 @@
     </div>
 
     <div class="page">
-        <h2 id="diagnostics-and-testing"><span>3</span>Diagnostics and Testing</h2>
+        <h2 id="section_3"><span>3</span>Diagnostics and Testing</h2>
         <p>Diagnostic steps have been successfully applied to the requested component.</p>
 
         <h3>Diagnostic Status</h3>


### PR DESCRIPTION
Prepends anchors and links in component-level documents with a reference to the component itself. This way, the compound document (the document that combines all these component-level documents of the same type into a single document) results in component-proper links across the entire document.