### PR TITLE
Fix/wording and typo in ra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+- Fix some wording the the RA document, and adjust a table in the chapter 4.2.1 ([49](https://github.com/opendevstack/ods-document-generation-templates/pull/49))
 ### Fixed - 2021-04-22
 - Fix the document history section for IVR still shows the wrong title ([#44](https://github.com/opendevstack/ods-document-generation-templates/pull/44))
 

--- a/templates/RA.html.tmpl
+++ b/templates/RA.html.tmpl
@@ -218,7 +218,6 @@
 				<td class="content-wrappable">Non-GxP risks are evaluated the same as GxP risks</td>
             </tr>
 			</table>
-			<p>Each non-GxP risk can have a different option for evaluation since the RNP is computed automatically. Thus, no project-level evaluation option is used. The selection is done individually in each Risk Assessment task. The value contains the GxP relevance and the number used to compute the RPN.</p>
 
 			<h3 id="section_4_2_2"><span>4.2.2</span>Probability of Occurrence</h3>
             {{#if data.sections.sec4s2s2.usesPoo}}

--- a/templates/RA.html.tmpl
+++ b/templates/RA.html.tmpl
@@ -154,12 +154,12 @@
             </tr>
 			<tr>
                 <td class="content-wrappable">Description of Risks/Failures (or reason for GxP = No)</td>
-                <td class="content-wrappable">Description of possible risks or failures associated with the requirement or function. More than one risk or failure may be associated with a requirement or function
+                <td class="content-wrappable">Description of possible risks or failures associated with the requirement or function. More than one risk or failure may be associated with a requirement or function.<br/>
 				If non-GxP risks are not evaluated, reason for classification as non-GxP is provided.</td>
             </tr>
 			<tr>
                 <td class="content-wrappable">Prob. of Occurrence</td>
-                <td class="content-wrappable">Relevance of the requirement or function for GxP or non-GxP (e.g. business). See section 4.2.1</td>
+                <td class="content-wrappable">Probability that the failure will occur.</td>
             </tr>
 			<tr>
                 <td class="content-wrappable">Severity of Impact</td>
@@ -194,32 +194,27 @@
             <tr>
                 <th>GxP Relevance</th>
                 <th>Value</th>
-                <th class="content-wrappable">GxP value in <a href="#section_5">section 5</a></th>
 				<th>Option</th>
 				<th>Description</th>
             </tr>
             <tr>
                 <td class="lean">Yes</td>
                 <td class="content-wrappable">2</td>
-                <td class="content-wrappable">R2</td>
 				<td class="content-wrappable">n/a</td>
 				<td class="content-wrappable">The requirement is directly related to GxP regulated activities. Failures could lead to incorrect data, loss of data, deterioration of product quality, or risk exposure for safety of patients or customers.</td>
             </tr>
 			<tr>
                 <td class="lean" rowspan="3">No</td>
-                <td class="content-wrappable">0</td>
-                <td class="content-wrappable">N0</td>
+                <td class="content-wrappable">n/a</td>
 				<td class="content-wrappable">Non-GxP risks are not being evaluated</td>
-				<td class="content-wrappable" rowspan="3">The requirement is directly related to GxP regulated activities. Failures could lead to incorrect data, loss of data, deterioration of product quality, or risk exposure for safety of patients or customers.</td>
+				<td class="content-wrappable" rowspan="3">The requirement has no GxP relevance. However, the requirement may have an impact on business. Failures could lead to e.g. system downtime, delay of submission process, loss of corporate reputation etc.</td>
             </tr>
 			<tr>
                 <td class="content-wrappable">1</td>
-                <td class="content-wrappable">N1</td>
 				<td class="content-wrappable">Non-GxP risks are evaluated lower than GxP risks</td>
             </tr>
 			<tr>
                 <td class="content-wrappable">2</td>
-                <td class="content-wrappable">N2</td>
 				<td class="content-wrappable">Non-GxP risks are evaluated the same as GxP risks</td>
             </tr>
 			</table>
@@ -470,6 +465,7 @@
 
 	<div class="page">
         <h2 id="section_8"><span>8</span>Document History</h2>
+        <p>The following table provides the history of the document.</p>
         {{#if data.documentHistory}}
         <table>
             <tr>


### PR DESCRIPTION
Changes to fix wording and typo in the RA document.
Change a table in the section 4.2.1 to remove the third column and some changes on the texts