### PR TITLE
Fix/missing rows in ivp template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Modified SSDS document to use Pull Request info not SonarQube ([#614](https://github.com/opendevstack/ods-jenkins-shared-library/pull/614))
 - Add missing table in RA document ([#50](https://github.com/opendevstack/ods-document-generation-templates/pull/50))
 - Add missing column in section 4 of TRC document ([#51](https://github.com/opendevstack/ods-document-generation-templates/pull/51))
-- Add missing rows in the table of the section 7 (conclussion) of the IVP document ([#52](https://github.com/opendevstack/ods-document-generation-templates/pull/52))
+- Remove table and add comment in the section 7 (conclusions) of the IVP document ([#52](https://github.com/opendevstack/ods-document-generation-templates/pull/52))
 - TIR and DTR documents are not properly indexed ([#47](https://github.com/opendevstack/ods-document-generation-templates/pull/47))
 
 ### Fixed - 2021-04-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Modified SSDS document to use Pull Request info not SonarQube ([#614](https://github.com/opendevstack/ods-jenkins-shared-library/pull/614))
 - Add missing table in RA document ([#50](https://github.com/opendevstack/ods-document-generation-templates/pull/50))
 - Add missing column in section 4 of TRC document ([#51](https://github.com/opendevstack/ods-document-generation-templates/pull/51))
-
+- Add missing rows in the table of the section 7 (conclussion) of the IVP document ([#52](https://github.com/opendevstack/ods-document-generation-templates/pull/52))
 ### Fixed - 2021-04-22
 - Fix the document history section for IVR still shows the wrong title ([#44](https://github.com/opendevstack/ods-document-generation-templates/pull/44))
 - Remove .idea directory ([#45](https://github.com/opendevstack/ods-document-generation-templates/pull/45))

--- a/templates/IVP.html.tmpl
+++ b/templates/IVP.html.tmpl
@@ -177,23 +177,7 @@ Other test cases:
 </div>
 
 <div class="page"><h2 id="section_7"><span>7</span>CONCLUSION</h2>
-	Having completed the execution of the CIT Plan of '{{metadata.name}}' and assessed the activities and respective outcomes, the conclusion drawn is as follows:<br>
-
-	<table>
-		<tr>
-			<td class="content-wrappable">&#x2610; Complete Success - no unresolved discrepencies</td>
-			<td class="content-wrappable">It is determined that all steps of the CIT Plan have been successfully executed and signature of this report verifies that the tests have been performed according to the plan. Either no discrepancies occurred or have been directly solved.</td>
-		</tr>
-		<tr>
-			<td class="content-wrappable">&#x2610; Success with unresolved discrepancies of low or medium severity</td>
-			<td class="content-wrappable">It is accepted that all essential steps of the CIT Plan have been successfully executed and signature of this report verifies that the testing has been performed according to the plan.<br>Discrepancies with low or medium severity were resolved directly or they are described below together with reasons why it is accepted that, overall, the plan has been successfully executed.</td>
-		</tr>
-		<tr>
-			<td class="content-wrappable">&#x2610; Unsuccessful with unresolved discrepancies which are not acceptable</td>
-			<td class="content-wrappable">Discrepancies or failures with high severity occurred that could not be remediated an acceptable level. The plan cannot be accepted as successfully executed. A new plan and/or test execution will be required. Enter additional information, if necessary:</td>
-		</tr>
-    </table>
-
+     The conclusion will be drawn on basis of the test results and documented in this chapter of the IVR.<br>
 </div>
 <div class="page"><h2 id="section_8"><span>8</span>DEFINITIONS AND ABBREVIATIONS</h2>
     <h3 id="section_8_1"><span>8.1</span>DEFINITIONS</h3>

--- a/templates/IVP.html.tmpl
+++ b/templates/IVP.html.tmpl
@@ -181,8 +181,16 @@ Other test cases:
 
 	<table>
 		<tr>
-			<td class="content-wrappable">Complete Success - no unresolved discrepencies</td>
+			<td class="content-wrappable">&#x2610; Complete Success - no unresolved discrepencies</td>
 			<td class="content-wrappable">It is determined that all steps of the CIT Plan have been successfully executed and signature of this report verifies that the tests have been performed according to the plan. Either no discrepancies occurred or have been directly solved.</td>
+		</tr>
+		<tr>
+			<td class="content-wrappable">&#x2610; Success with unresolved discrepancies of low or medium severity</td>
+			<td class="content-wrappable">It is accepted that all essential steps of the CIT Plan have been successfully executed and signature of this report verifies that the testing has been performed according to the plan.<br>Discrepancies with low or medium severity were resolved directly or they are described below together with reasons why it is accepted that, overall, the plan has been successfully executed.</td>
+		</tr>
+		<tr>
+			<td class="content-wrappable">&#x2610; Unsuccessful with unresolved discrepancies which are not acceptable</td>
+			<td class="content-wrappable">Discrepancies or failures with high severity occurred that could not be remediated an acceptable level. The plan cannot be accepted as successfully executed. A new plan and/or test execution will be required. Enter additional information, if necessary:</td>
 		</tr>
     </table>
 


### PR DESCRIPTION
In the IVP template, there were two row missing in the conclussion table, with this fix we add the missing information as exists in the word template of the document