### PR TITLE
Improve naming of xUnit attachment section to name inclusion of test evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Updated section 12 in SSDS-5 to remove SonarQube references ([#55](https://github.com/opendevstack/ods-document-generation-templates/pull/55))
 - Add support for ods-saas-service component type ([#31](https://github.com/opendevstack/ods-document-generation-templates/pull/31))
 - Fix failure in CSD for GAMP 5 ([#57](https://github.com/opendevstack/ods-document-generation-templates/pull/57))
+- Improve naming of xUnit attachment section to name inclusion of test evidence ([#58](https://github.com/opendevstack/ods-document-generation-templates/pull/58))
 
 ### Fixed - 2021-04-22
 - Fix the document history section for IVR still shows the wrong title ([#44](https://github.com/opendevstack/ods-document-generation-templates/pull/44))

--- a/templates/DTR.html.tmpl
+++ b/templates/DTR.html.tmpl
@@ -94,7 +94,7 @@
             <li><a href="#section_7">Document History</a></li>
             <li><a href="#section_8">Attachments</a>
                 <ol>
-                    <li><a href="#section_8_1">xUnit XML Documents</a></li>
+                    <li><a href="#section_8_1">xUnit XML Documents (including Test Evidence)</a></li>
                 </ol>
             </li>
         </ol>
@@ -112,7 +112,7 @@
 
     <div class="page">
         <h2 id="section_3"><span>3</span>Development Testing Results</h2>
-		<p>Please, see chapter <a href="#section_8_1">"8.1 xUnit XML Documents"</a> to consult the exhaustive Development Testing Results.</p>
+		<p>Please, see chapter <a href="#section_8_1">"8.1 xUnit XML Documents (including Test Evidence)"</a> to consult the exhaustive Development Testing Results.</p>
 
         <h3 id="section_3_1"><span>3.1</span>Overview of Unit Tested Modules</h3>
         {{#if data.tests}}
@@ -259,8 +259,8 @@
 
     <div class="page">
         <h2 id="section_8"><span>8</span>Attachments</h2>
-        <h3 id="section_8_1"><span>8.1</span>xUnit XML Documents</h3>
-        <p>The information included in this test results provides the xUnit XML results of the execution of the system {{metadata.name}} created by Jenkins Job Name {{metadata.jenkins.jobName}} and Jenkins Build Number {{metadata.jenkins.buildNumber}}.</p>
+        <h3 id="section_8_1"><span>8.1</span>xUnit XML Documents (including Test Evidence)</h3>
+        <p>This section provides the xUnit XML results, including any test evidence, of the execution of the system {{metadata.name}} created by Jenkins Job Name {{metadata.jenkins.jobName}} and Jenkins Build Number {{metadata.jenkins.buildNumber}}.</p>
 		{{#if data.testFiles}}
 			{{#each data.testFiles}}
 			<h4>{{name}}</h4>

--- a/templates/IVR.html.tmpl
+++ b/templates/IVR.html.tmpl
@@ -94,7 +94,7 @@
         </li>
 		<li><a href="#section_13">Attachments</a>
 			<ol>
-				<li><a href="#section_13_1">xUnit XML Documents</a></li>
+				<li><a href="#section_13_1">xUnit XML Documents (including Test Evidence)</a></li>
 			</ol>
 		</li>
     </ol>
@@ -507,8 +507,8 @@ Other test cases:
 
 <div class="page">
 	<h2 id="section_13"><span>13</span>Attachments</h2>
-	<h3 id="section_13_1"><span>13.1</span>xUnit XML Documents</h3>
-	<p>The information included in this test results provides the xUnit XML results of the execution of the system {{metadata.name}} created by Jenkins Job Name {{metadata.jenkins.jobName}} and Jenkins Build Number {{metadata.jenkins.buildNumber}}.</p>
+	<h3 id="section_13_1"><span>13.1</span>xUnit XML Documents (including Test Evidence)</h3>
+	<p>This section provides the xUnit XML results, including any test evidence, of the execution of the system {{metadata.name}} created by Jenkins Job Name {{metadata.jenkins.jobName}} and Jenkins Build Number {{metadata.jenkins.buildNumber}}.</p>
 	{{#if data.testFiles}}
 		{{#each data.testFiles}}
 		<h4>{{name}}</h4>

--- a/templates/TCR.html.tmpl
+++ b/templates/TCR.html.tmpl
@@ -85,7 +85,7 @@
             </li>
 			<li><a href="#section_4">Attachments</a>
                 <ol>
-                    <li><a href="#section_4_1">xUnit XML Documents</a></li>
+                    <li><a href="#section_4_1">xUnit XML Documents (including Test Evidence)</a></li>
                 </ol>
             </li>
         </ol>
@@ -357,8 +357,8 @@
     </div>
     <div class="page">
         <h2 id="section_4"><span>4</span>Attachments</h2>
-        <h3 id="section_4_1"><span>4.1</span>xUnit XML Documents</h3>
-        <p>The information included in this test results provides the xUnit XML results of the execution of the system {{metadata.name}} created by Jenkins Job Name {{metadata.jenkins.jobName}} and Jenkins Build Number {{metadata.jenkins.buildNumber}}.</p>
+        <h3 id="section_4_1"><span>4.1</span>xUnit XML Documents (including Test Evidence)</h3>
+        <p>This section provides the xUnit XML results, including any test evidence, of the execution of the system {{metadata.name}} created by Jenkins Job Name {{metadata.jenkins.jobName}} and Jenkins Build Number {{metadata.jenkins.buildNumber}}.</p>
 
         <h4 id="section_4_1_1"><span>4.1.1</span>Integration Test Cases</h4>
 		{{#if data.integrationTestFiles}}


### PR DESCRIPTION
This improves usability so auditors can more easily identify the sections containing test evidence.