### PR TITLE
Fix table truncated in SSDS due to email addresses size that cannot be broken cause it contains underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Allow Discrepancies in EDP Templates([#84](https://github.com/opendevstack/ods-document-generation-templates/pull/84))
 - Fix CI name of Container PAAS system references([#85](https://github.com/opendevstack/ods-document-generation-templates/pull/85))
+- Fix truncated table in SSDS when emails cannot be truncated ([#86](https://github.com/opendevstack/ods-document-generation-templates/pull/86))
 
 ## 1.2 - 2022-02-18
 ### Added

--- a/css/styles.css
+++ b/css/styles.css
@@ -277,3 +277,7 @@ table td.hyphenate {
     -moz-hyphens: auto;
     hyphens: auto;
 }
+
+.break-all{
+  word-break: break-all;
+}

--- a/templates/SSDS-1.html.tmpl
+++ b/templates/SSDS-1.html.tmpl
@@ -158,12 +158,12 @@
                     <tr>
                         <td class="content-wrappable">{{date}}</td>
                         <td class="content-wrappable">{{component}}</td>
-                        <td class="content-wrappable">
+                        <td class="content-wrappable break-all" style="min-width: 200px;">
                             <ul>
                                 <li>{{authorName}}, {{authorEmail}}</li>
                             </ul>
                         </td>
-                        <td class="content-wrappable">
+                        <td class="content-wrappable break-all" style="min-width: 200px;">
                             <ul>
                             {{#each reviewers}}
                                 <li>{{reviewerName}}, {{reviewerEmail}}</li>

--- a/templates/SSDS-3.html.tmpl
+++ b/templates/SSDS-3.html.tmpl
@@ -158,12 +158,12 @@
                     <tr>
                         <td class="content-wrappable">{{date}}</td>
                         <td class="content-wrappable">{{component}}</td>
-                        <td class="content-wrappable">
+                        <td class="content-wrappable break-all" style="min-width: 200px;">
                             <ul>
                                 <li>{{authorName}}, {{authorEmail}}</li>
                             </ul>
                         </td>
-                        <td class="content-wrappable">
+                        <td class="content-wrappable break-all" style="min-width: 200px;">
                             <ul>
                             {{#each reviewers}}
                                 <li>{{reviewerName}}, {{reviewerEmail}}</li>

--- a/templates/SSDS-4.html.tmpl
+++ b/templates/SSDS-4.html.tmpl
@@ -157,12 +157,12 @@
                     <tr>
                         <td class="content-wrappable">{{date}}</td>
                         <td class="content-wrappable">{{component}}</td>
-                        <td class="content-wrappable">
+                        <td class="content-wrappable break-all" style="min-width: 200px;">
                             <ul>
                                 <li>{{authorName}}, {{authorEmail}}</li>
                             </ul>
                         </td>
-                        <td class="content-wrappable">
+                        <td class="content-wrappable break-all" style="min-width: 200px;">
                             <ul>
                             {{#each reviewers}}
                                 <li>{{reviewerName}}, {{reviewerEmail}}</li>

--- a/templates/SSDS-5.html.tmpl
+++ b/templates/SSDS-5.html.tmpl
@@ -162,12 +162,12 @@
                     <tr>
                         <td class="content-wrappable">{{date}}</td>
                         <td class="content-wrappable">{{component}}</td>
-                        <td class="content-wrappable">
+                        <td class="content-wrappable break-all" style="min-width: 200px;">
                             <ul>
                                 <li>{{authorName}}, {{authorEmail}}</li>
                             </ul>
                         </td>
-                        <td class="content-wrappable">
+                        <td class="content-wrappable break-all" style="min-width: 200px;">
                             <ul>
                             {{#each reviewers}}
                                 <li>{{reviewerName}}, {{reviewerEmail}}</li>


### PR DESCRIPTION
The content can be broken in any character in the columns that contains the emails, but had ad mininum size to avoid collapse it to a 1 or 2 characters width.