### PR TITLE
Rename concrete BuildConfig and DeploymentConfig to *Resource

### DIFF
--- a/templates/TIR.html.tmpl
+++ b/templates/TIR.html.tmpl
@@ -182,7 +182,7 @@
 		      <table>
 		      {{#each .}}
 		        <tr>
-		          BuildConfig: <b>{{@key}}</b>
+		          Build Resource: <b>{{@key}}</b>
 		          <table>
 		            <tr>
 		                <th>Name</th>
@@ -204,7 +204,7 @@
 		      <table>
 		      {{#each .}}
 		        <tr>
-		          DeploymentConfig: <b>{{@key}}</b>
+		          Deployment Resource: <b>{{@key}}</b>
 		          <table>
 		            <tr>
 		                <th>Name</th>


### PR DESCRIPTION
To support the parallel Helm integration with the Release Manager we want to use more abstract names.