### PR TITLE
Bugfix/cftr document presents an inconsistent behaviour between testing sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Bugfix/cftr document presents an inconsistent behaviour between testing sections ([#124](https://github.com/opendevstack/ods-document-generation-templates/pull/124))
 - Remove overlapping headers for tables spanning multiple pages ([#121](https://github.com/opendevstack/ods-document-generation-templates/pull/121))
 - Remove CFTR reference from TRC document ([#115](https://github.com/opendevstack/ods-document-generation-templates/pull/115))
 - RA: GxP Relevance section available for GxP projects only ([#118](https://github.com/opendevstack/ods-document-generation-templates/issues/118))

--- a/templates/CFTR-3.html.tmpl
+++ b/templates/CFTR-3.html.tmpl
@@ -153,8 +153,8 @@
 
         <h3 id="section_3_5"><span>3.5</span>Acceptance Testing Results</h3>
             <h4 id="section_3_5_1"><span>3.5.1 </span>Functional Testing Results</h4>
-            <p>The table below lists all Functional tests as defined during the risk assessment and additional optional tests created and executed during development. Not all of those tests are necessarily GxP relevant. To identify GxP-relevant tests please refer to the Risk Assessment or Traceability Matrix.</p>
 				{{#if data.acceptanceTests}}
+                <p>The table below lists all Functional tests as defined during the risk assessment and additional optional tests created and executed during development. Not all of those tests are necessarily GxP relevant. To identify GxP-relevant tests please refer to the Risk Assessment or Traceability Matrix.</p>
 				<table>
 					<thead>
 						<th class="lean">ID from Jira</th>

--- a/templates/CFTR-4.html.tmpl
+++ b/templates/CFTR-4.html.tmpl
@@ -182,8 +182,8 @@
 
         <h3 id="section_3_5"><span>3.5</span>Acceptance Testing Results</h3>
             <h4 id="section_3_5_1"><span>3.5.1 </span>Functional Testing Results</h4>
-            <p>The table below lists all Functional tests as defined during the risk assessment and additional optional tests created and executed during development. Not all of those tests are necessarily GxP relevant. To identify GxP-relevant tests please refer to the Risk Assessment or Traceability Matrix.</p>
 				{{#if data.acceptanceTests}}
+                <p>The table below lists all Functional tests as defined during the risk assessment and additional optional tests created and executed during development. Not all of those tests are necessarily GxP relevant. To identify GxP-relevant tests please refer to the Risk Assessment or Traceability Matrix.</p>
 				<table>
 					<thead>
 						<th class="lean">ID from Jira</th>

--- a/templates/CFTR-5.html.tmpl
+++ b/templates/CFTR-5.html.tmpl
@@ -181,9 +181,9 @@
         <p>Additional Integration Tests not defined in Jira and executed: {{data.numAdditionalIntegrationTests}}</p>
 
         <h3 id="section_3_5"><span>3.5</span>Acceptance Testing Results</h3>
-            <h4 id="section_3_5_1"><span>3.5.1 </span>Functional Testing Results</h4>
-            <p>The table below lists all Functional tests as defined during the risk assessment and additional optional tests created and executed during development. Not all of those tests are necessarily GxP relevant. To identify GxP-relevant tests please refer to the Risk Assessment or Traceability Matrix.</p>
+            <h4 id="section_3_5_1"><span>3.5.1 </span>Functional Testing Results</h4>            
 				{{#if data.acceptanceTests}}
+                <p>The table below lists all Functional tests as defined during the risk assessment and additional optional tests created and executed during development. Not all of those tests are necessarily GxP relevant. To identify GxP-relevant tests please refer to the Risk Assessment or Traceability Matrix.</p>
 				<table>
 					<thead>
 						<th class="lean">ID from Jira</th>


### PR DESCRIPTION
CFTR document presents an inconsistent behaviour between INTEGRATION TESTING RESULTS and ACCEPTANCE TESTING RESULTS sections

PRECONDITIONS
Have a release/version in Jira
Not having defined in the release any INTEGRATION or ACCEPTANCE test

STEPS
perform a "Deploy to D"
freeze the release by confirming documents are signed
perform a "Deploy to Q"
download the document CFTR and scroll down to chapters 3.4 and 3.5

EXPECTED B.
Since there are no tests defined, a N/A text is applied to both 3.4 INTEGRATION and 3.5.1 FUNCTIONAL testing results and
the text that comes from the template explaining the nature of the table is not displayed for both sections

ACTUAL B.
for 3.4 INTEGRATION TESTING RESULTS: n/a is displayed and no explanatory text is offered
BUT, for 3.5.1 n/a is printed but alongside the explanatory text for a non-existing table.{}