### PR TITLE
Fix CSD file with block <p>N/A</p> always present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 - Make risk level column in Overview of Unit Tested Modules (in DTP and DTR) wrappable  ([#144](https://github.com/opendevstack/ods-document-generation-templates/pull/144))
+- Fix CSD file with block <p>N/A</p> always present ([#147](https://github.com/opendevstack/ods-document-generation-templates/pull/147))
+
 
 ## 1.2.8 - 2024-06-06
 - RA doc in section 4.1 has got a typo in Description of column Requirement ([#142](https://github.com/opendevstack/ods-document-generation-templates/pull/142))

--- a/templates/CSD-1.html.tmpl
+++ b/templates/CSD-1.html.tmpl
@@ -198,7 +198,7 @@
                     </table>
                 {{/each}}
              {{else}}
-             <p>N/A</p>/p>
+             <p>N/A</p>
              {{/if}}
 
 

--- a/templates/CSD-5.html.tmpl
+++ b/templates/CSD-5.html.tmpl
@@ -268,7 +268,6 @@
                                 <td class="lean">{{applicability}}</td>
                             </tr>
                             {{/each}}
-             <p>N/A</p>
                     </table>
                 {{/each}}
              {{else}}


### PR DESCRIPTION
The CSD document has a block N/A always present:
![image](https://github.com/user-attachments/assets/a56c2c1e-68a9-48de-b2d9-51410bb546f6)
