### PR TITLE
Remove Jira issue ID strikethrough on SLC documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Remove Jira issue ID strikethrough on SLC documents. ([#153](https://github.com/opendevstack/ods-document-generation-templates/pull/153))
 - Make content in column Test Case No. wrappable. ([#152](https://github.com/opendevstack/ods-document-generation-templates/pull/152))
 
 ## 1.2.10 - 2025-1-27

--- a/css/styles.css
+++ b/css/styles.css
@@ -47,6 +47,9 @@ h5 span {
   margin-right: 1.5em;
 }
 
+del {
+  text-decoration: none;
+}
 
 input + label {
   margin-left: 0.5em;


### PR DESCRIPTION
Remove the strikethrough in Jira issues references in docs. Example:
![image](https://github.com/user-attachments/assets/cca81423-e186-4b38-904f-7f6a51ee2da3)
After the fix:
![image](https://github.com/user-attachments/assets/3a1f3baa-8baa-4270-b908-50466b82f6dc)
