### PR TITLE
Remove hardcoded prerequisite row from TCP/TCR templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Remove prerequisites section from TCP tests ([#162](https://github.com/opendevstack/ods-document-generation-templates/pull/162))
+- Remove hard-coded prerequisites section from TCP and TCR templates ([#162](https://github.com/opendevstack/ods-document-generation-templates/pull/162))
 
 ## 1.2.13 - 2025-7-10
 - Fixed the document history of the TIR for ods-infra components ([#160](https://github.com/opendevstack/ods-document-generation-templates/pull/160))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+- Remove prerequisites section from TCP tests
 
 ## 1.2.13 - 2025-7-10
 - Fixed the document history of the TIR for ods-infra components ([#160](https://github.com/opendevstack/ods-document-generation-templates/pull/160))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Remove prerequisites section from TCP tests
+- Remove prerequisites section from TCP tests ([#162](https://github.com/opendevstack/ods-document-generation-templates/pull/162))
 
 ## 1.2.13 - 2025-7-10
 - Fixed the document history of the TIR for ods-infra components ([#160](https://github.com/opendevstack/ods-document-generation-templates/pull/160))

--- a/templates/TCP.html.tmpl
+++ b/templates/TCP.html.tmpl
@@ -181,10 +181,6 @@
                         <th class="lean">Target Environment:</th>
                         <td>{{../metadata.buildParameter.targetEnvironmentToken}}</td>
                     </tr>
-                    <tr>
-                        <th class="lean">Prerequisites:</th>
-                        <td>N/A</td>
-                    </tr>
                 </table>
                 <div class="page">
                     <table>
@@ -249,10 +245,6 @@
                     <tr>
                         <th class="lean">Target Environment:</th>
                         <td>{{../metadata.buildParameter.targetEnvironmentToken}}</td>
-                    </tr>
-                    <tr>
-                        <th class="lean">Prerequisites:</th>
-                        <td>N/A</td>
                     </tr>
                 </table>
 

--- a/templates/TCR.html.tmpl
+++ b/templates/TCR.html.tmpl
@@ -190,10 +190,6 @@
                         <th class="lean">Target Environment:</th>
                         <td>{{../metadata.buildParameter.targetEnvironmentToken}}</td>
                     </tr>
-                    <tr>
-                        <th class="lean">Prerequisites:</th>
-                        <td>N/A</td>
-                    </tr>
                 </table>
                 <div class="page">
                     <table>
@@ -258,10 +254,6 @@
                     <tr>
                         <th class="lean">Target Environment:</th>
                         <td>{{../metadata.buildParameter.targetEnvironmentToken}}</td>
-                    </tr>
-                    <tr>
-                        <th class="lean">Prerequisites:</th>
-                        <td>N/A</td>
                     </tr>
                 </table>
 


### PR DESCRIPTION
agreement with CSV&C that prerequsite row in TCP template was not necessary