### PR TITLE
fix: TCP and TCR render root data property for steps test data if test data is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix empty test data in test step doing parent context traversal ([#166](https://github.com/opendevstack/ods-document-generation-templates/pull/166))
 
 
 ## 1.2.14 - 2026-06-30

--- a/templates/TCP.html.tmpl
+++ b/templates/TCP.html.tmpl
@@ -196,7 +196,7 @@
                         <tr>
                             <td>{{orderId}}</td>
                             <td class="content-wrappable">{{{step}}}</td>
-                            <td class="content-wrappable">{{{data}}}</td>
+                            <td class="content-wrappable">{{{this.data}}}</td>
                             <td class="content-wrappable">{{{result}}}</td>
                             <td class="content-wrappable">{{{actualResult}}}</td>
                         </tr>
@@ -264,7 +264,7 @@
                         <tr>
                             <td>{{orderId}}</td>
                             <td class="content-wrappable">{{{step}}}</td>
-                            <td class="content-wrappable">{{{data}}}</td>
+                            <td class="content-wrappable">{{{this.data}}}</td>
                             <td class="content-wrappable">{{{result}}}</td>
                             <td>{{{../actualResult}}}</td>
                         </tr>

--- a/templates/TCR.html.tmpl
+++ b/templates/TCR.html.tmpl
@@ -205,7 +205,7 @@
                         <tr>
                             <td>{{orderId}}</td>
                             <td class="content-wrappable">{{{step}}}</td>
-                            <td class="content-wrappable">{{{data}}}</td>
+                            <td class="content-wrappable">{{{this.data}}}</td>
                             <td class="content-wrappable">{{{result}}}</td>
                             <td class="content-wrappable">{{{../actualResult}}}</td>
                         </tr>
@@ -273,7 +273,7 @@
                         <tr>
                             <td>{{orderId}}</td>
                             <td class="content-wrappable">{{{step}}}</td>
-                            <td class="content-wrappable">{{{data}}}</td>
+                            <td class="content-wrappable">{{{this.data}}}</td>
                             <td class="content-wrappable">{{{result}}}</td>
                             <td class="content-wrappable">{{{actualResult}}}</td>
                         </tr>


### PR DESCRIPTION
test steps for automated tests can have test data equals null this causes handlebars to consider the parent contexts leading it to use the data property from root instead of the data property of the individual test step